### PR TITLE
Fix for taking of snapshots during mesh scans

### DIFF
--- a/HardwareObjects/queue_entry.py
+++ b/HardwareObjects/queue_entry.py
@@ -647,8 +647,6 @@ class DataCollectionQueueEntry(BaseQueueEntry):
 
             if self.beamline_setup.in_plate_mode():
                 acq_1.acquisition_parameters.take_snapshots = False
-            else:
-                acq_1.acquisition_parameters.take_snapshots = True
 
             sample = self.get_data_model().get_parent().get_parent()
             param_list = queue_model_objects.\


### PR DESCRIPTION
This patch removes the forcing of snap shot images in case mxCuBE is not in plate mode. Removing these two lines allows the workflow to determine whether snapshots should be taken or not. The default value of take_snapshots for acquisition_parameters is True so taking of snapshots will still be the default behaviour.
