### PR TITLE
More generalized cleanup procedure: introduced new method data_collectio...

### DIFF
--- a/HardwareObjects/AbstractMultiCollect.py
+++ b/HardwareObjects/AbstractMultiCollect.py
@@ -193,6 +193,12 @@ class AbstractMultiCollect(object):
 
 
     @abc.abstractmethod
+    @task
+    def data_collection_cleanup(self):
+        pass
+
+
+    @abc.abstractmethod
     def get_wavelength(self):
       pass
 
@@ -577,7 +583,7 @@ class AbstractMultiCollect(object):
 
         self.move_motors(motors_to_move_before_collect)
 
-        with cleanup(self.close_fast_shutter):
+        with cleanup(self.data_collection_cleanup):
             self.open_safety_shutter(timeout=10)
 
             self.prepare_intensity_monitors()

--- a/HardwareObjects/ESRFMultiCollect.py
+++ b/HardwareObjects/ESRFMultiCollect.py
@@ -293,6 +293,11 @@ class ESRFMultiCollect(AbstractMultiCollect, HardwareObject):
 
 
     @task
+    def data_collection_cleanup(self):
+        self.execute_command("close_fast_shutter")
+
+
+    @task
     def close_fast_shutter(self):
         self.execute_command("close_fast_shutter")
 


### PR DESCRIPTION
...n_cleanup

instead of simply calling close_fast_shutter for cleanup. The data_collection_cleanup
can then be easily customised for each institute.
In order to keep the old ESRF behaviour, overwrite abstract method in ESRFMultiCollect
and call close_fast_shutter from there.
