### PR TITLE
Add lims_id to beamline_parameters

### DIFF
--- a/Bricks/widgets/create_workflow_widget.py
+++ b/Bricks/widgets/create_workflow_widget.py
@@ -137,6 +137,7 @@ class CreateWorkflowWidget(CreateTaskBase):
         beamline_params['run_number'] = wf.path_template.run_number
         beamline_params['collection_software'] = 'mxCuBE - 2.0'
         beamline_params['sample_node_id'] = sample._node_id
+        beamline_params['sample_lims_id'] = sample.lims_id
 
         params_list = map(str, list(itertools.chain(*beamline_params.iteritems())))
         params_list.insert(0, self.workflows[wf_name]['path'])


### PR DESCRIPTION
This patch will allow the workflows to obtain the ISPyB blSampleId for the sample being measured. I have tested this patch on ID23-1 on Tuesday April 15th (MDT).
