### PR TITLE
move login logic from ProposalBrick2 to ISPyBClient2 HO

### DIFF
--- a/Bricks/ProposalBrick2.py
+++ b/Bricks/ProposalBrick2.py
@@ -30,7 +30,7 @@ class ProposalBrick2(BlissWidget):
         self.dbConnection=None
         self.localLogin=None
         self.session_hwobj = None
-
+       
         # Initialize session info
         self.proposal=None
         self.session=None
@@ -38,6 +38,7 @@ class ProposalBrick2(BlissWidget):
         self.laboratory=None
         #self.sessionId=None
         self.inhouseProposal=None
+	self.loginType = "proposal"
 
         self.instanceServer=None
 
@@ -66,16 +67,24 @@ class ProposalBrick2(BlissWidget):
         self.contentsBox.setInsideSpacing(5)
 
         self.loginBox=QHBox(self.contentsBox, 'login_box')
-        code_label=QLabel("  Code: ",self.loginBox)
+
+        self.code_label=QLabel("  Code: ",self.loginBox)
         self.propType=QComboBox(self.loginBox)
         self.propType.setEditable(True)
         self.propType.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.MinimumExpanding)
         self.propType.setPaletteBackgroundColor(widget_colors.LIGHT_RED)
-        dash_label=QLabel(" - ",self.loginBox)
+        self.dash_label=QLabel(" - ",self.loginBox)
         self.propNumber=QLineEdit(self.loginBox)
         self.propNumber.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.MinimumExpanding)
         self.propNumber.setPaletteBackgroundColor(widget_colors.LIGHT_RED)
         self.propNumber.setFixedWidth(50)
+	
+        self.userName=QLineEdit(self.loginBox)
+        self.userName.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.MinimumExpanding)
+        self.userName.setPaletteBackgroundColor(widget_colors.LIGHT_RED)
+        self.userName.setFixedWidth(75)
+	self.userName.hide()
+
         password_label=QLabel("   Password: ",self.loginBox)
         self.propPassword=QLineEdit(self.loginBox)
         self.propPassword.setEchoMode(QLineEdit.Password)
@@ -461,12 +470,19 @@ class ProposalBrick2(BlissWidget):
         self.user_group_ledit.setText('')
         self.setEnabled(False)
 
-        prop_type=str(self.propType.currentText())
-        prop_number=str(self.propNumber.text())
-        prop_password=str(self.propPassword.text())
+        propType=str(self.propType.currentText())
+        propNumber=str(self.propNumber.text()) or ""
+	userName = str(self.userName.text()) or ""
+        password=str(self.propPassword.text())
         self.propPassword.setText("")
 
-        if prop_type=="" and prop_number=="":
+	if self.loginType == "proposal":
+	    loginID = "%s%s" % (propType,propNumber)
+	else:
+	    loginID= userName
+	
+        # try local login if userID is empty
+        if propNumber =="" and userName == "":
             if self.localLogin is None:
                 return self.refuseLogin(False,"Local login not configured.")
             try:
@@ -474,7 +490,7 @@ class ProposalBrick2(BlissWidget):
             except AttributeError:
                 return self.refuseLogin(False,"Local login not configured.")
 
-            if prop_password!=locallogin_password:
+            if password!=locallogin_password:
                 return self.refuseLogin(None,"Invalid local login password.")
 
             now=time.strftime("%Y-%m-%d %H:%M:S")
@@ -489,15 +505,28 @@ class ProposalBrick2(BlissWidget):
             cont_dict={'familyName':'local contact'}
 
             logging.getLogger().debug("ProposalBrick: local login password validated")
-            
             return self.acceptLogin(prop_dict,pers_dict,lab_dict,ses_dict,cont_dict)
 
-        if self.ldapConnection == None:
-            return self.refuseLogin(False,'Not connected to LDAP, unable to verify password.')
         if self.dbConnection == None:
             return self.refuseLogin(False,'Not connected to the ISPyB database, unable to get proposal.')
-
-        self._do_login(prop_type,prop_number,prop_password, self.dbConnection.beamline_name)
+         
+	loginRes=self.dbConnection.login(loginID,password)
+	try:
+            login_ok=(loginRes['status']['code']=='ok')
+        except KeyError:
+            login_ok=False
+        if not login_ok:
+	    if loginRes['status']['code'] == 'ispybDown':
+		self.ispybDown()
+		return
+            else:
+                self.refuseLogin(False, loginRes['status']['msg'])
+	else:
+	    # login succeed but without a scheduled session, a newSession is created instead. Ask the user to accep the new session
+            if loginRes['session']['new_session_flag']:
+                if not  self.askForNewSession():
+                    return self.refuseLogin(None,None)
+            self.acceptLogin(loginRes['Proposal'],loginRes['person'],loginRes['laboratory'],loginRes['session']['session'],loginRes['local_contact'])
 
     def passControl(self,has_control_id):
         pass
@@ -515,6 +544,8 @@ class ProposalBrick2(BlissWidget):
             self.localLogin=self.getHardwareObject(newValue)
         elif propertyName=='dbConnection':
             self.dbConnection = self.getHardwareObject(newValue)
+	    logging.getLogger().info("dbconnection is %s", str(newValue))
+	    self.updateLoginID()
         elif propertyName=='instanceServer':
             if self.instanceServer is not None:
                 self.disconnect(self.instanceServer,PYSIGNAL('passControl'), self.passControl)
@@ -538,114 +569,22 @@ class ProposalBrick2(BlissWidget):
         else:
             BlissWidget.propertyChanged(self,propertyName,oldValue,newValue)
 
-    def _do_login(self, proposal_code,proposal_number,proposal_password,beamline_name, impersonate=False):
-        if not impersonate:
-            login_name=self.dbConnection.translate(proposal_code,'ldap')+str(proposal_number)
-            logging.getLogger().debug('ProposalBrick: querying LDAP...')
-            ok, msg=self.ldapConnection.login(login_name,proposal_password)
-            if not ok:
-                msg="%s." % msg.capitalize()
-                self.refuseLogin(None,msg)
-                return
-
-            logging.getLogger().debug("ProposalBrick: password for %s-%s validated" % (proposal_code,proposal_number))
-
-        # Get proposal and sessions
-        logging.getLogger().debug('ProposalBrick: querying ISPyB database...')
-        prop=self.dbConnection.getProposal(proposal_code,proposal_number)
-
-        # Check if everything went ok
-        prop_ok=True
-        try:
-            prop_ok=(prop['status']['code']=='ok')
-        except KeyError:
-            prop_ok=False
-        if not prop_ok:
-            self.ispybDown()
-            return
-
-        logging.getLogger().debug('ProposalBrick: got sessions from ISPyB...')
-
-        proposal=prop['Proposal']
-        person=prop['Person']
-        laboratory=prop['Laboratory']
-        try:
-            sessions=prop['Session']
-        except KeyError:
-            sessions=None
-
-        # Check if there are sessions in the proposal
-        todays_session=None
-        if sessions is None or len(sessions)==0:
-            pass
-        else:
-            # Check for today's session
-            for session in sessions:
-                beamline=session['beamlineName']
-                start_date="%s 00:00:00" % session['startDate'].split()[0]
-                end_date="%s 23:59:59" % session['endDate'].split()[0]
-                try:
-                    start_struct=time.strptime(start_date,"%Y-%m-%d %H:%M:%S")
-                except ValueError:
-                    pass
-                else:
-                    try:
-                        end_struct=time.strptime(end_date,"%Y-%m-%d %H:%M:%S")
-                    except ValueError:
-                        pass
-                    else:
-                        start_time=time.mktime(start_struct)
-                        end_time=time.mktime(end_struct)
-                        current_time=time.time()
-
-                        # Check beamline name
-                        if beamline==beamline_name:
-                            # Check date
-                            if current_time>=start_time and current_time<=end_time:
-                                todays_session=session
-                                break
-
-        if todays_session is None:
-            is_inhouse = self.session_hwobj.is_inhouse(proposal["code"], proposal["number"])
-            if not is_inhouse:
-                if BlissWidget.isInstanceRoleClient():
-                    self.refuseLogin(None,"You don't have a session scheduled for today!")
-                    return
-
-                if not self.askForNewSession():
-                    self.refuseLogin(None,None)
-                    return
-
-            current_time=time.localtime()
-            start_time=time.strftime("%Y-%m-%d 00:00:00", current_time)
-            end_time=time.mktime(current_time)+60*60*24
-            tomorrow=time.localtime(end_time)
-            end_time=time.strftime("%Y-%m-%d 07:59:59", tomorrow)
-
-            # Create a session
-            new_session_dict={}
-            new_session_dict['proposalId']=prop['Proposal']['proposalId']
-            new_session_dict['startDate']=start_time
-            new_session_dict['endDate']=end_time
-            new_session_dict['beamlineName']=beamline_name
-            new_session_dict['scheduled']=0
-            new_session_dict['nbShifts']=3
-            new_session_dict['comments']="Session created by the BCM"
-            session_id=self.dbConnection.createSession(new_session_dict)
-            new_session_dict['sessionId']=session_id
-
-            todays_session=new_session_dict
-            localcontact=None
-        else:
-            session_id=todays_session['sessionId']
-            logging.getLogger().debug('ProposalBrick: getting local contact for %s' % session_id)
-            localcontact=self.dbConnection.getSessionLocalContact(session_id)
-
-        self.acceptLogin(prop['Proposal'],\
-            prop['Person'],\
-            prop['Laboratory'],\
-            todays_session,\
-            localcontact)
+    def updateLoginID(self):
+	if self.loginType == self.dbConnection.loginType:
+	    return
+        self.loginType = self.dbConnection.loginType
+        if self.loginType == "proposal":
+	    self.code_label.setText("  Code: ")
+            self.userName.hide()
+	    self.propType.show()
+	    self.dash_label.show()
+	    self.propNumber.show()
+	else:
+            self.code_label.setText("  User ID: ")
+	    self.userName.show()
+            self.propType.hide()
+            self.dash_label.hide()
+            self.propNumber.hide()
 
 
 ### Auxiliary method to merge a person's name


### PR DESCRIPTION
It's for the ISPyBClient2 HO in the 2.1 branch. I am doing the PR in case you want to test it during the merge of the 2.1 to the master branch. At least it's done, you don't have to reinvent the wheel.

The interface is loginType dependent (defined in lims.xml). For proposal (default) login, it is still the same as before, but for user login, it does not have the ComboBox for proposal type.

Btw, Login error msg from LDAP is forwarded to the brick through ispybclient2.py
