### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Latest information about the MXCuBE project can be found in the
 ## Information for developers
 
 * [How to install and run Qt version] (https://github.com/mxcube/mxcube/blob/master/docs/source/installation_instructions_qt4.rst)
-* [How to install and run Web version] (https://github.com/mxcube/mxcube/blob/master/docs/source/installation_instructions_web.rst)
+* [How to install and run Web version] (https://github.com/mxcube/mxcube3/wiki/How-to:-Installation)
 
 More detailed information is available in the [docs directory] 
 (https://github.com/mxcube/mxcube/tree/master/docs). Use [sphinx] (http://sphinx-doc.org/) to build the documentation.


### PR DESCRIPTION
Mxcube3 installation instructions points to mxcube3 wiki, just to minimize confusion since there was two different places with (in-complete) instructions
