### PR TITLE
Fix spelling of MXCuBE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 MXCuBE stands for Macromolecular Xtallography Customized Beamline Environment.
 The project started in 2005 at [ESRF](http://www.esrf.eu), since then it has
 been adopted by other institutes in Europe. In 2010, a collaboration
-agreement has been signed for the development of mxCuBE with the following
+agreement has been signed for the development of MXCuBE with the following
 partners:
 * ESRF
 * [Soleil](http://www.synchrotron-soleil.fr/)


### PR DESCRIPTION
I also see that MXCuBE is spelled MxCuBE (lowercase x) in the citation for MXCuBE at the bottom, but I didn't change it thinking it might be important not to change a citation for a paper that has already been published?  If it doesn't matter, then the citation should be changed too (i.e. the x should be uppercase).
