### PR TITLE
Fix bug in PyQt5 version

### DIFF
--- a/BlissFramework/QtImport.py
+++ b/BlissFramework/QtImport.py
@@ -128,7 +128,9 @@ if (qt_variant == 'PyQt5') or (qt_variant is None and not qt_imported):
         qt_imported = True
         qt_variant = "PyQt5"
         qt_version_no = list(map(int,QT_VERSION_STR.split(".")))
-        pyqt_version_no = list(map(int,PYQT_VERSION_STR.split(".")))[:3]
+        _ver = PYQT_VERSION_STR.split(".")
+        ver = _ver + ['0']*(3 - len(_ver))
+        pyqt_version_no = list(map(int,ver))[:3]
     except:
         pass
 
@@ -168,7 +170,9 @@ if (qt_variant == 'PyQt4') or (qt_variant is None and not qt_imported):
         qt_imported = True
         qt_variant = "PyQt4"
         qt_version_no = list(map(int,QT_VERSION_STR.split(".")))
-        pyqt_version_no = list(map(int,PYQT_VERSION_STR.split(".")))[:3]
+        _ver = PYQT_VERSION_STR.split(".")
+        ver = _ver + ['0']*(3 - len(_ver))
+        pyqt_version_no = list(map(int,ver))[:3]
     except:
         pass
 


### PR DESCRIPTION
The QtImport module fails to properly parse the string version
of the PyQt5 module. A 2-digit version is returned  but 3-digit
expected.

The soluton is to append as many 0's as necessary at the end of
the version name to fulfill a 3-digits version.