### PR TITLE
[master] 2017.09.12. Updated Qt4 bricks

### DIFF
--- a/BlissFramework/Bricks/EMBL/Qt4_MarvinBrick.py
+++ b/BlissFramework/Bricks/EMBL/Qt4_MarvinBrick.py
@@ -133,20 +133,20 @@ class Qt4_MarvinBrick(BlissWidget):
         self.focus_mode_ledit.setFixedWidth(80)
 
         self.puck_switches_table.setRowCount(1)
-        self.puck_switches_table.setColumnCount(16)
+        self.puck_switches_table.setColumnCount(17)
         self.puck_switches_table.verticalHeader().hide()
         self.puck_switches_table.horizontalHeader().hide()
         self.puck_switches_table.setRowHeight(0, 20)
         self.puck_switches_table.setFixedHeight(26)
         self.puck_switches_table.setShowGrid(True)
 
-        for col_index in range(16):
+        for col_index in range(17):
             temp_item = QTableWidgetItem(str(col_index + 1))
             temp_item.setFlags(Qt.ItemIsEnabled)
             temp_item.setBackground(Qt4_widget_colors.WHITE)
             self.puck_switches_table.setItem(0, col_index, temp_item)
             self.puck_switches_table.setColumnWidth(col_index, 22)
-            self.puck_switches_table.setFixedWidth(22 * 16 + 6)
+            self.puck_switches_table.setFixedWidth(22 * 17 + 6)
 
         self.status_table.setColumnCount(3)
         self.status_table.setHorizontalHeaderLabels(["Property", "Description", "Value"])

--- a/BlissFramework/Bricks/Qt4_AttenuatorsBrick.py
+++ b/BlissFramework/Bricks/Qt4_AttenuatorsBrick.py
@@ -170,6 +170,7 @@ class Qt4_AttenuatorsBrick(BlissWidget):
 
         if self.new_value_validator.validate(input_field_text, 0)[0] == \
            QValidator.Acceptable:
+            self.new_value_ledit.setEnabled(False)
             self.attenuators_hwobj.setTransmission(\
                  float(input_field_text))
             self.new_value_ledit.setText("") 
@@ -200,7 +201,8 @@ class Qt4_AttenuatorsBrick(BlissWidget):
         Args.     :
         Return.   : 
         """
-        if transmission_state in self.states: 
+        self.new_value_ledit.setEnabled(transmission_state == "ready")
+        if transmission_state in self.states:
             color = self.states[transmission_state]
         else: 
             color = self.states["UNKNOWN"]

--- a/BlissFramework/Bricks/Qt4_EnergyBrick.py
+++ b/BlissFramework/Bricks/Qt4_EnergyBrick.py
@@ -207,6 +207,7 @@ class Qt4_EnergyBrick(BlissWidget):
 
     def state_changed(self, state):
         self.setEnabled(state == "ready")
+        BlissWidget.set_status_info("status", "", "")
 
     def status_info_changed(self, status_info):
         self.status_ledit.setText(status_info)
@@ -222,6 +223,7 @@ class Qt4_EnergyBrick(BlissWidget):
         if self.new_value_validator.validate(input_field_text, 0)[0] == \
            QValidator.Acceptable:
             if self.units_combobox.currentIndex() == 0:
+                BlissWidget.set_status_info("status", "Setting energy...", "running")
                 self.energy_hwobj.move_energy(float(input_field_text))
             else:
                 self.energy_hwobj.move_wavelength(float(input_field_text))

--- a/BlissFramework/Bricks/Qt4_HutchMenuBrick.py
+++ b/BlissFramework/Bricks/Qt4_HutchMenuBrick.py
@@ -265,14 +265,15 @@ class Qt4_HutchMenuBrick(BlissWidget):
         Args.     : 
         Return    : 
         """
-        if self.full_centring_done:
+        #if self.full_centring_done:
+        if True:
             Qt4_widget_colors.set_widget_color(self.accept_button, 
                                                self.standard_color)
             self.reject_button.setEnabled(False)
             self.graphics_manager_hwobj.accept_centring()
             self.full_centring_done = False
-        else:
-            self.graphics_manager_hwobj.start_centring(tree_click=False)
+        #else:
+        #    self.graphics_manager_hwobj.start_centring(tree_click=False)
 
     def reject_clicked(self):
         """

--- a/BlissFramework/Bricks/Qt4_MDPhaseBrick.py
+++ b/BlissFramework/Bricks/Qt4_MDPhaseBrick.py
@@ -116,7 +116,7 @@ class Qt4_MDPhaseBrick(BlissWidget):
         Descript. :
         """
         if self.diffractometer_hwobj is not None:
-            self.diffractometer_hwobj.set_phase(self.phase_combobox.currentText())
+            self.diffractometer_hwobj.set_phase(self.phase_combobox.currentText(), timeout=None)
 
     def phase_changed(self, phase):
         """
@@ -127,6 +127,5 @@ class Qt4_MDPhaseBrick(BlissWidget):
             #index = self.phase_combobox.findText(phase) 
             #self.phase_combobox.setEditText(phase)
             self.phase_combobox.setCurrentIndex(self.phase_combobox.findText(phase))
-            self.phase_combobox.setEnabled(True)
         else:
-            self.phase_combobox.setEnabled(False) 
+            self.phase_combobox.setCurrentIndex(-1) 

--- a/BlissFramework/Bricks/Qt4_MotorSpinBoxBrick.py
+++ b/BlissFramework/Bricks/Qt4_MotorSpinBoxBrick.py
@@ -73,6 +73,7 @@ class Qt4_MotorSpinBoxBrick(BlissWidget):
         self.addProperty('showPosition', 'boolean', True)
         self.addProperty('invertButtons', 'boolean', False)
         self.addProperty('delta', 'string', '')
+        self.addProperty('decimals', 'integer', 2)
         self.addProperty('icons', 'string', '')
         self.addProperty('helpDecrease', 'string', '')
         self.addProperty('helpIncrease', 'string', '')
@@ -255,6 +256,9 @@ class Qt4_MotorSpinBoxBrick(BlissWidget):
         Return.   : 
         """
         return self.position_spinbox.singleStep()
+
+    def set_decimals(self, decimals):
+        self.position_spinbox.setDecimals(decimals)
 
     def set_line_step(self, val):
         """
@@ -773,6 +777,8 @@ class Qt4_MotorSpinBoxBrick(BlissWidget):
                 for default_step in default_step_list:
                     self.set_line_step(float(default_step))
                 self.step_changed(None)
+        elif property_name == 'decimals':
+             self.position_spinbox.setDecimals(new_value)
         elif property_name == 'showSlider':
             self.position_slider.setVisible(new_value)
         elif property_name == 'enableSliderTracking':

--- a/BlissFramework/Bricks/Qt4_MultipleMotorsBrick.py
+++ b/BlissFramework/Bricks/Qt4_MultipleMotorsBrick.py
@@ -49,9 +49,10 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
         self.addProperty('mnemonic', 'string', '')
         self.addProperty('labels', 'string','')
         self.addProperty('moveButtonIcons', 'string','') 
-        self.addProperty('alignment', 'combo', ('vertical', 'horizontal'), 'horizontal')
-        self.addProperty('defaultStep', 'string', '0.01')
-        self.addProperty('delta', 'string', '0.01')
+        self.addProperty('alignment', 'combo', ('vertical', 'horizontal'), 'vertical')
+        self.addProperty('defaultSteps', 'string', '')
+        self.addProperty('defaultDeltas', 'string', '')
+        self.addProperty('defaultDecimals', 'string', '')
         self.addProperty('predefinedPositions', 'string', '')
         self.addProperty('showMoveButtons', 'boolean', True)
         self.addProperty('showSlider', 'boolean', False)
@@ -93,7 +94,12 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
     def propertyChanged(self, property_name, old_value, new_value):
         if property_name == 'mnemonic':
             hwobj_names_list = new_value.split()
-            for hwobj_name in hwobj_names_list:
+
+            default_delta_list = self['defaultDeltas'].split()
+            default_decimal_list = self['defaultDecimals'].split()
+            default_step_list = self['defaultSteps'].split()
+
+            for index, hwobj_name in enumerate(hwobj_names_list):
                 temp_motor_hwobj = self.getHardwareObject(hwobj_name)
                 if temp_motor_hwobj is not None:
                     temp_motor_widget = Qt4_MotorSpinBoxBrick(self)
@@ -103,9 +109,23 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
                     temp_motor_widget.position_slider.setVisible(self['showSlider'])
                     temp_motor_widget.step_button.setVisible(self['showStep'])
                     temp_motor_widget.stop_button.setVisible(self['showStop'])
-                    temp_motor_widget.set_line_step(self['defaultStep'])
-                    temp_motor_widget['defaultStep'] = self['defaultStep']
-                    temp_motor_widget['delta'] = self['delta']
+                    
+                    try:  
+                        temp_motor_widget.set_line_step(default_step_list[index])
+                        temp_motor_widget['defaultStep'] = default_step_list[index]
+                    except:
+                        temp_motor_widget.set_line_step(0.001)
+                        temp_motor_widget['defaultStep'] = 0.001
+
+                    try:    
+                        temp_motor_widget['delta'] = default_delta_list[index]
+                    except:
+                        temp_motor_widget['delta'] = 0.001
+                    try:
+                        temp_motor_widget.set_decimals(default_decimal_list[index])
+                    except:
+                        pass
+                    
                     temp_motor_widget.step_changed(None)
                     self.main_groupbox_hlayout.addWidget(temp_motor_widget)
 
@@ -130,7 +150,7 @@ class Qt4_MultipleMotorsBrick(BlissWidget):
                     self.motor_widget_list[index / 2].move_left_button.setIcon(\
                          Qt4_Icons.load_icon(icon_list[index]))
                     self.motor_widget_list[index / 2].move_right_button.setIcon(\
-                         Qt4_Icons.load_icon(icon_list[index + 1])) 
+                         Qt4_Icons.load_icon(icon_list[index + 1]))
         elif property_name == 'labels':
             self.motor_widget_labels = new_value.split()
             if len(self.motor_widget_list):

--- a/BlissFramework/Bricks/Qt4_SampleChangerBrick3.py
+++ b/BlissFramework/Bricks/Qt4_SampleChangerBrick3.py
@@ -592,6 +592,7 @@ class CurrentSampleView(CurrentView):
 class StatusView(QWidget):
 
     statusMsgChangedSignal = pyqtSignal(str, QColor)
+    resetSampleChangerSignal = pyqtSignal()
 
     def __init__(self, parent):
         QWidget.__init__(self, parent)
@@ -651,7 +652,7 @@ class StatusView(QWidget):
         # SizePolicies --------------------------------------------------------
 
         # Qt signal/slot connections ------------------------------------------
-        self.reset_button.clicked.connect(self.resetSampleChanger)
+        self.reset_button.clicked.connect(self.reset_sample_changer)
         self.sc_can_load_radiobutton.clicked.connect(self.sampleChangerMoveToLoadingPos)
         self.minidiff_can_move_radiobutton.clicked.connect(self.minidiffGetControl)
 
@@ -683,7 +684,7 @@ class StatusView(QWidget):
         self.sc_can_load_radiobutton.setEnabled(enabled)
         self.minidiff_can_move_radiobutton.setEnabled(enabled)
 
-    def setExpertMode(self, state):
+    def set_expert_mode(self, state):
         self.in_expert_mode = state
         self.reset_button.setEnabled(state)
         self.minidiff_can_move_radiobutton.setEnabled(state)
@@ -712,7 +713,7 @@ class StatusView(QWidget):
         self.minidiff_can_move_radiobutton.setEnabled(self.in_expert_mode)
         self.minidiff_can_move_radiobutton.setChecked(can_move)
 
-    def resetSampleChanger(self):
+    def reset_sample_changer(self):
         self.resetSampleChangerSignal.emit()
 
     def sampleChangerMoveToLoadingPos(self):
@@ -900,6 +901,7 @@ class Qt4_SampleChangerBrick3(BlissWidget):
 
         self.test_sample_changer_button.clicked.connect(self.test_sample_changer)
         self.reset_baskets_samples_button.clicked.connect(self.resetBasketsSamplesInfo)
+        self.status.resetSampleChangerSignal.connect(self.resetSampleChanger)
 
     def propertyChanged(self, property_name, old_value, new_value):
         if property_name == 'icons':
@@ -1053,14 +1055,14 @@ class Qt4_SampleChangerBrick3(BlissWidget):
     def resetBasketsSamplesInfo(self):
         self.sample_changer_hwobj.clearInfo()
 
-    def setExpertMode(self, state):
+    def set_expert_mode(self, state):
         self.in_expert_mode = state
         if self.sample_changer_hwobj is not None:
-            self.status.setExpertMode(state)
+            self.status.set_expert_mode(state)
 
     def run(self):
         if self.in_expert_mode is not None:
-            self.setExpertMode(self.in_expert_mode)
+            self.set_expert_mode(self.in_expert_mode)
         try:
             self.matrixCodesChanged(self.sample_changer_hwobj.getMatrixCodes())
         except:

--- a/BlissFramework/Bricks/Qt4_ToolsBrick.py
+++ b/BlissFramework/Bricks/Qt4_ToolsBrick.py
@@ -41,6 +41,7 @@ class Qt4_ToolsBrick(BlissWidget):
 
         # Hardware objects ----------------------------------------------------
         self.tools_hwobj = None
+        self.action_dict = {}
 
         # Internal values -----------------------------------------------------
 
@@ -79,14 +80,32 @@ class Qt4_ToolsBrick(BlissWidget):
         pass
 
     def init_tools(self):
-        """
-        Gets available methods and populates menubar with methods
-        If icon name exists then adds icon
+        """Gets available methods and populates menubar with methods
+           If icon name exists then adds icon
         """
         self.tools_list = self.tools_hwobj.get_tools_list()
-        for tool in self.tools_list:
-            if hasattr(tool["hwobj"], tool["method"]): 
+        for index, tool in enumerate(self.tools_list):
+            if tool == "separator":
+                self.tools_menu.addSeparator()
+            elif hasattr(tool["hwobj"], tool["method"]):
                 temp_action = self.tools_menu.addAction(\
-                   tool["display"], getattr(tool["hwobj"], tool["method"]))
-                if len(tool["icon"]) > 0:
+                    tool["display"],
+                    self.execute_tool)
+                if tool.get("icon"):
                     temp_action.setIcon(Qt4_Icons.load_icon(tool["icon"]))
+                self.action_dict[temp_action] = tool
+
+    def execute_tool(self):
+        """Executes tool asigned to the menu action
+           Asks for a confirmation if a tool has a conformation msg.
+        """
+        for key in self.action_dict.keys():
+            if key == self.sender():
+                tool = self.action_dict[key]
+                if tool.get("confirmation"):
+                    conf_dialog = QMessageBox.warning(None, "Question",
+                         tool["confirmation"], QMessageBox.Ok, QMessageBox.Cancel)
+                    if conf_dialog == QMessageBox.Ok:
+                        getattr(tool["hwobj"], tool["method"])()
+                else:
+                    getattr(tool["hwobj"], tool["method"])()


### PR DESCRIPTION
* BlissFramework/Bricks/EMBL/Qt4_MarvinBrick.py: fixed bugs
* BlissFramework/Bricks/Qt4_AttenuatorsBrick.py: disable widget after value sent. Enable widget when state is ready
* BlissFramework/Bricks/Qt4_EnergyBrick.py: set message to the statebar
* BlissFramework/Bricks/Qt4_HutchMenuBrick.py: fixed accept centring button
* BlissFramework/Bricks/Qt4_MDPhaseBrick.py: set current index to -1 if phase is unknown
* BlissFramework/Bricks/Qt4_MotorSpinBoxBrick.py: added property to set decimal numbers
* BlissFramework/Bricks/Qt4_MultipleMotorsBrick.py: likewise
* BlissFramework/Bricks/Qt4_SampleChangerBrick3.py: fixed reset butto
* BlissFramework/Bricks/Qt4_ToolsBrick.py: added handling of dialog box if requested from xml