### PR TITLE
Replaced tabs with spaces in Python code

### DIFF
--- a/BlissFramework/BaseComponents.py
+++ b/BlissFramework/BaseComponents.py
@@ -616,16 +616,16 @@ class BlissWidget(QWidget, Connectable.Connectable):
 
 
     def connectSignalSlotFilter(self,sender,signal,slot,should_cache):
-	#print "CONNECTING ", sender, signal, slot
+        #print "CONNECTING ", sender, signal, slot
         uid=(sender, signal, hash(slot))
-	signalSlotFilter = SignalSlotFilter(signal, slot, should_cache)
+        signalSlotFilter = SignalSlotFilter(signal, slot, should_cache)
         self._signalSlotFilters[uid]=signalSlotFilter
 
-	QObject.connect(sender, signal, signalSlotFilter)
+        QObject.connect(sender, signal, signalSlotFilter)
 
 
     def connect(self, sender, signal, slot, instanceFilter=False, shouldCache=True):
-	signal = str(signal)
+        signal = str(signal)
         if signal[0].isdigit():
           pysignal = signal[0]=='9'
           signal=signal[1:]
@@ -640,7 +640,7 @@ class BlissWidget(QWidget, Connectable.Connectable):
           else:
             _sender = emitter(sender)
         else:
-	    _sender = sender
+            _sender = sender
 
         if instanceFilter:
             self.connectSignalSlotFilter(_sender, pysignal and PYSIGNAL(signal) or SIGNAL(signal), slot, shouldCache)
@@ -653,7 +653,7 @@ class BlissWidget(QWidget, Connectable.Connectable):
     
 
     def disconnect(self, sender, signal, slot):
-	signal = str(signal)
+        signal = str(signal)
         if signal[0].isdigit():
           pysignal = signal[0]=='9'
           signal=signal[1:]
@@ -953,9 +953,9 @@ class ProcedureBrick(BlissWidget):
     def setMnemonic(self, mne):
         self.getProperty('mnemonic').setValue(mne)
 
- 	proc = HardwareRepository.HardwareRepository().getProcedure(mne)
+        proc = HardwareRepository.HardwareRepository().getProcedure(mne)
 
-	self.__setProcedure(proc)
+        self.__setProcedure(proc)
 
 
     def __setProcedure(self, proc):
@@ -1008,7 +1008,7 @@ class ProcedureBrick(BlissWidget):
         
     def propertyChanged(self, property, oldValue, newValue):
         if property == 'mnemonic':
-       	    self.setMnemonic(newValue) #Procedure(HardwareRepository.HardwareRepository().getHardwareObject(newValue))
+            self.setMnemonic(newValue) #Procedure(HardwareRepository.HardwareRepository().getHardwareObject(newValue))
         elif property == 'equipment':
             self.setEquipment(self.getHardwareObject(newValue))
 

--- a/BlissFramework/Bricks/ALBA/Qt4_ALBA_MachineInfoBrick.py
+++ b/BlissFramework/Bricks/ALBA/Qt4_ALBA_MachineInfoBrick.py
@@ -133,7 +133,7 @@ class Qt4_ALBA_MachineInfoBrick(BlissWidget):
         Return.   : 
         """
         txt = '??? mA' if values[0] is None else '<b>%s</b> mA' % \
-	       str(self['formatString'] % abs(values[0]))
+               str(self['formatString'] % abs(values[0]))
         self.current_value_label.setText(txt)
         self.logger.debug("Setting values %s" % repr(values)) 
         

--- a/BlissFramework/Bricks/AdscTemperatureMonitorBrick.py
+++ b/BlissFramework/Bricks/AdscTemperatureMonitorBrick.py
@@ -20,7 +20,7 @@ class TemperaturePanel(qt.QWidget):
 
   def setTemperatures(self, temp_list):
     try:
-    	self.temp_list = map(float, temp_list[:self.nccds])
+        self.temp_list = map(float, temp_list[:self.nccds])
     except:
         self.temp_list = self.nccds*[None]
 

--- a/BlissFramework/Bricks/AttenuatorsBrick.py
+++ b/BlissFramework/Bricks/AttenuatorsBrick.py
@@ -97,7 +97,7 @@ from BlissFramework.Utils import widget_colors
 class AtteFilter(QCheckBox):
     def __init__(self,label,parent,idx):
         QCheckBox.__init__(self,str(label),parent)
-	self.idx=idx
+        self.idx=idx
         self.connect(self,SIGNAL("toggled(bool)"),self.toggleme)
 
     def toggleme(self):
@@ -389,7 +389,7 @@ class FiltersDialog(QDialog):
         self.accept()
 
     def toggleFilter(self,filter_id):
-    	#print "dialog.toggleFilter",filter_id
+        #print "dialog.toggleFilter",filter_id
         self.attenuators.toggle(filter_id)
 
     def filtersChanged(self,value):

--- a/BlissFramework/Bricks/BeamstopBrick.py
+++ b/BlissFramework/Bricks/BeamstopBrick.py
@@ -242,4 +242,4 @@ class BeamstopBrick(DuoStateBrick):
     def stopClicked(self):
         for motor in self.beamstop.motors:
             self.beamstop.motors[motor].stop()
-	return
+        return

--- a/BlissFramework/Bricks/BrowserBrick.py
+++ b/BlissFramework/Bricks/BrowserBrick.py
@@ -55,7 +55,7 @@ class BrowserBrick(BaseComponents.BlissWidget):
         self.sort_col = None
 
         self.history = QTable(self.history_box)
-	self.history.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.MinimumExpanding))
+        self.history.setSizePolicy(QSizePolicy(QSizePolicy.Minimum, QSizePolicy.MinimumExpanding))
         self.history.setSelectionMode(QTable.SingleRow)
         self.history.setNumCols(3)
         self.history.verticalHeader().hide()
@@ -109,7 +109,7 @@ class BrowserBrick(BaseComponents.BlissWidget):
 
         self.browser = QTextBrowser(self.browser_box)
         self.browser.setReadOnly(True)
-	self.browser_box.layout().addWidget(self.browser)
+        self.browser_box.layout().addWidget(self.browser)
 
         self.layout.addWidget(self.main_layout)
 
@@ -173,7 +173,7 @@ class BrowserBrick(BaseComponents.BlissWidget):
             pass
 
     def new_html(self, html_path, image_prefix, run_number):
-	logging.getLogger().debug('got a new html page: %s, prefix: %r, run number: %s', html_path, image_prefix, run_number)
+        logging.getLogger().debug('got a new html page: %s, prefix: %r, run number: %s', html_path, image_prefix, run_number)
 
         # prepend the time and date to the path we just got so
         # the history is more readable

--- a/BlissFramework/Bricks/CameraBrick.py
+++ b/BlissFramework/Bricks/CameraBrick.py
@@ -359,10 +359,10 @@ class CameraBrick(BlissWidget):
             self.__hwoName   = newValue
 
             if self.camera is not None:
-		try:
+                try:
                     self.__tangoName = self.camera.tangoname
-		except:
-		    self.__tangoName = ""
+                except:
+                    self.__tangoName = ""
 
                 try:
                     camera_role=self.camera.getDeviceByRole('camera')

--- a/BlissFramework/Bricks/CameraMotorToolsBrick.py
+++ b/BlissFramework/Bricks/CameraMotorToolsBrick.py
@@ -375,18 +375,18 @@ class CameraMotorToolsBrick(BlissWidget):
                 self.limitsAction = None
 
         if self.measureMode is not None:
-		if self.measureAction is None:
-			self.measureAction = QubOpenDialogAction(parent=self, name='measure', iconName='measure', label='Measure', group='Tools', place=self.measureMode)
-			self.measureAction.setConnectCallBack(self._measure_dialog_new)
+                if self.measureAction is None:
+                        self.measureAction = QubOpenDialogAction(parent=self, name='measure', iconName='measure', label='Measure', group='Tools', place=self.measureMode)
+                        self.measureAction.setConnectCallBack(self._measure_dialog_new)
                         logging.getLogger().info("setting measure mode")
-			if self.view is not None:
-				logging.getLogger().info("adding action")
-				self.view.addAction(self.measureAction)
-	else:
-		if self.measureAction is not None:
-			if self.view is not None:
-				self.view.delAction(self.measureAction)
-			self.measureAction = None
+                        if self.view is not None:
+                                logging.getLogger().info("adding action")
+                                self.view.addAction(self.measureAction)
+        else:
+                if self.measureAction is not None:
+                        if self.view is not None:
+                                self.view.delAction(self.measureAction)
+                        self.measureAction = None
 
         if self.movetoMode is not None:
             if self.__movetoActionMosaic is not None:
@@ -435,15 +435,15 @@ class CameraMotorToolsBrick(BlissWidget):
     
     def _measure_dialog_new(self,openDialogAction,aQubImage) :
         if  self.YSize is not None and self.ZSize is not None:
-    	  self.__measureDialog = QubMeasureListDialog(self,
+            self.__measureDialog = QubMeasureListDialog(self,
                                                       canvas=aQubImage.canvas(),
                                                       matrix=aQubImage.matrix(),
                                                       eventMgr=aQubImage)
-          self.__measureDialog.setXPixelSize(self.YSize/1000.0)
-          self.__measureDialog.setYPixelSize(self.ZSize/1000.0)
-          self.__measureDialog.connect(aQubImage, qt.PYSIGNAL("ForegroundColorChanged"),
+            self.__measureDialog.setXPixelSize(self.YSize/1000.0)
+            self.__measureDialog.setYPixelSize(self.ZSize/1000.0)
+            self.__measureDialog.connect(aQubImage, qt.PYSIGNAL("ForegroundColorChanged"),
                                        self.__measureDialog.setDefaultColor)
-          openDialogAction.setDialog(self.__measureDialog)
+            openDialogAction.setDialog(self.__measureDialog)
         
     def setHorizontalPosition(self, newPosition):
         if self.limitsAction is not None:        
@@ -510,7 +510,7 @@ class CameraMotorToolsBrick(BlissWidget):
         if sizey is not None:
             self.YSize = sizey * 1000
             try:
-		self.__measureDialog.setXPixelSize(sizey)
+                self.__measureDialog.setXPixelSize(sizey)
             except:
                 pass
         else:

--- a/BlissFramework/Bricks/CommandBrick.py
+++ b/BlissFramework/Bricks/CommandBrick.py
@@ -88,7 +88,7 @@ class CommandButton(QVBox):
           entryWidgetsGrid.setMargin(5)
 
           for argname, argtype, onchange, valuefrom in self.arguments:
-	    QLabel(argname, entryWidgetsGrid)
+            QLabel(argname, entryWidgetsGrid)
             QLabel(' : ', entryWidgetsGrid)
             cmdobj = DummyCallable()
             chanobj = None
@@ -160,8 +160,8 @@ class CommandButton(QVBox):
         cmdObject.connectSignal('commandAborted', self.commandReplyArrived)
         cmdObject.connectSignal('connected', self.connected)
         cmdObject.connectSignal('disconnected', self.disconnected)
-	cmdObject.connectSignal('commandReady', self.enableCommand)
-	cmdObject.connectSignal('commandNotReady', self.disableCommand)
+        cmdObject.connectSignal('commandReady', self.enableCommand)
+        cmdObject.connectSignal('commandNotReady', self.disableCommand)
         self.connect(self.cmdExecute, SIGNAL('clicked()'), self.launchCommand)
 
 
@@ -305,7 +305,7 @@ class CommandBrick(BlissWidget):
 
             if hasattr(self.hardwareObject, 'getChannels'):
                 for chan in self.hardwareObject.getChannels():
-	            self.channelLabels.append(QLabel('<nobr><b>%s</b></nobr>' % str(chan.name()), self.channelsBox))
+                    self.channelLabels.append(QLabel('<nobr><b>%s</b></nobr>' % str(chan.name()), self.channelsBox))
                     self.channelLabels[-1].setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
                     self.channelLabels.append(ChannelLabel(chan, self.channelsBox))
                     self.channelLabels[-1].setNumberFormatString(self['numberFormatString'])
@@ -332,7 +332,7 @@ class CommandBrick(BlissWidget):
                         self.cmdButtons[-1].connected()
                     else:
                         self.cmdButtons[-1].disconnected()
-	    else:
+            else:
                 self.hardwareObject = None
                 logging.getLogger().error("%s: hardware object does not contain any command", ho.name())
 
@@ -344,11 +344,11 @@ class CommandBrick(BlissWidget):
                 if i % 2:
                     self.channelLabels[i].setNumberFormatString(self['numberFormatString'])
         elif property == 'title':
-	    if len(newValue) == 0:
-	       self.lblTitle.hide()
+            if len(newValue) == 0:
+               self.lblTitle.hide()
             else:
-	       self.lblTitle.show()
-	       self.lblTitle.setText(newValue)
+               self.lblTitle.show()
+               self.lblTitle.setText(newValue)
             self.adjustSize()
         elif property == 'commands_channels': 
             try:

--- a/BlissFramework/Bricks/DataCollectResultsWidget.py
+++ b/BlissFramework/Bricks/DataCollectResultsWidget.py
@@ -125,7 +125,7 @@ class DetectorImage(VideoDisplay.VideoDisplayWidget):
         #print "setWantedImage",directory,template,image_number
         if self.imageServer is not None:
             self.wantedImage=[directory,template,image_number]
-	    self.wantedImageUpdated(delay)
+            self.wantedImageUpdated(delay)
 
     def clearImage(self,current_also=False):
         #print "clearImage"

--- a/BlissFramework/Bricks/EDNAParameters.py
+++ b/BlissFramework/Bricks/EDNAParameters.py
@@ -262,7 +262,7 @@ class EDNAParameters(BlissWidget):
         #output_dir = self.beamline_params['directory'].replace('RAW_DATA', 'PROCESSED_DATA')
         # we'll need that one later to pass to the edna characterise HO
         #self.process_dir = output_dir
-	#if not os.path.exists(output_dir):
+        #if not os.path.exists(output_dir):
         #    os.makedirs(output_dir)
         #(handle, filename) = tempfile.mkstemp(suffix='.xml', prefix='edna_output_', dir=output_dir)
         #blparams.output_file = filename
@@ -278,9 +278,9 @@ class EDNAParameters(BlissWidget):
     def updateBeamlineParameters(self, params):
         logging.debug('got beamline param update, new values: %r', params)
         self.beamline_params = dict()
-	# as XSDataSomethingSomething marshalling routing uses format string
-	# BUT does not enforces its arg type, we have to do some type
-	# conversion, lest it will explode when we call marshal() on it
+        # as XSDataSomethingSomething marshalling routing uses format string
+        # BUT does not enforces its arg type, we have to do some type
+        # conversion, lest it will explode when we call marshal() on it
         floats = ['exposure_time', 'resolution', 'resolution_at_corner', 'x_beam', 'y_beam', 'beam_size_x', 'beam_size_y', 'overlap', 'osc_start', 'osc_range', 'kappaStart', 'current_detdistance', 'current_wavelength', 'phiStart', 'current_energy', 'current_osc_start'] 
         ints = ['sessionId', 'blSampleId', 'first_image', 'number_images', 'run_number', 'number_passes'] 
         for k,v in params.iteritems():

--- a/BlissFramework/Bricks/EDNAParameters.py
+++ b/BlissFramework/Bricks/EDNAParameters.py
@@ -280,7 +280,7 @@ class EDNAParameters(BlissWidget):
         self.beamline_params = dict()
 	# as XSDataSomethingSomething marshalling routing uses format string
 	# BUT does not enforces its arg type, we have to do some type
-	# conversion, lest it will explode when we call marshal() on it       
+	# conversion, lest it will explode when we call marshal() on it
         floats = ['exposure_time', 'resolution', 'resolution_at_corner', 'x_beam', 'y_beam', 'beam_size_x', 'beam_size_y', 'overlap', 'osc_start', 'osc_range', 'kappaStart', 'current_detdistance', 'current_wavelength', 'phiStart', 'current_energy', 'current_osc_start'] 
         ints = ['sessionId', 'blSampleId', 'first_image', 'number_images', 'run_number', 'number_passes'] 
         for k,v in params.iteritems():

--- a/BlissFramework/Bricks/EMBL/Qt4_MarvinBrick.py
+++ b/BlissFramework/Bricks/EMBL/Qt4_MarvinBrick.py
@@ -39,7 +39,7 @@ class Qt4_MarvinBrick(BlissWidget):
         Descript. :
         """
         BlissWidget.__init__(self, *args)
-	
+
         # Hardware objects ----------------------------------------------------
         self.sample_changer_hwobj = None
 

--- a/BlissFramework/Bricks/EnergyScanBrick.py
+++ b/BlissFramework/Bricks/EnergyScanBrick.py
@@ -161,7 +161,7 @@ class EnergyScanBrick(BlissWidget):
         self.instanceSynchronize("parametersBox","prefixInput","directoryInput","peakInput","inflectionInput","remoteInput","remote2Input")
 
         self.choochGraphs = QtBlissGraph(self)
-	self.choochGraphs.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed) 
+        self.choochGraphs.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         QVBoxLayout(self)
         self.layout().addWidget(self.parametersBox)

--- a/BlissFramework/Bricks/FiltersBrick.py
+++ b/BlissFramework/Bricks/FiltersBrick.py
@@ -240,7 +240,7 @@ class MotorizedFilterTable( FilterTable ):
    def setFilters(self,axisno,filters):
         self.filtpos[axisno] = range(len(filters))
 
-	filts = []
+        filts = []
         for filterno in range(len(filters)):
             filter = filters[filterno][0] #username
             pos = filters[filterno][1] #offset

--- a/BlissFramework/Bricks/GraphBrick.py
+++ b/BlissFramework/Bricks/GraphBrick.py
@@ -412,7 +412,7 @@ class GraphBrick(BlissWidget):
             QToolTip.add(self.cmdSaveData, tp)
             
             self.cmdSaveData.setEnabled(len(newValue) > 0)
-	elif property.startswith('instanceAllow'):
+        elif property.startswith('instanceAllow'):
             BlissWidget.propertyChanged(self, property, oldValue, newValue)
         else:
             self.addCurve(newValue)

--- a/BlissFramework/Bricks/HutchMenuBrick.py
+++ b/BlissFramework/Bricks/HutchMenuBrick.py
@@ -39,14 +39,14 @@ class HutchMenuBrick(BlissWidget):
         BlissWidget.__init__(self, *args)
 
         self.minidiff = None
-	self.beamInfo = None
+        self.beamInfo = None
         self.sampleChanger=None
         self.collectObj = None
         self.queue_hwobj = None
-	self.beam_position = None
+        self.beam_position = None
         self.beam_size = None
-	self.beam_shape = None
-	self.pixels_per_mm = None
+        self.beam_shape = None
+        self.pixels_per_mm = None
         #self.allowMoveToBeamCentring = False
 
         # Define properties
@@ -60,7 +60,7 @@ class HutchMenuBrick(BlissWidget):
         self.addProperty('label','string','Sample centring')
         self.addProperty('displayBeam', 'boolean', True)
         self.addProperty('queue', 'string', '/queue')
-	self.addProperty('useMDPhases', 'boolean', False)
+        self.addProperty('useMDPhases', 'boolean', False)
 
         # Define signals and slots
         self.defineSignal('enableMinidiff',())
@@ -126,7 +126,7 @@ class HutchMenuBrick(BlissWidget):
         self.buttonToogleMDPhase.setMinimumSize(QSize(75,50))
         self.buttonToogleMDPhase.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         QObject.connect(self.buttonToogleMDPhase,SIGNAL('clicked()'),self.toggleMDPhase)
-	self.buttonToogleMDPhase.hide()
+        self.buttonToogleMDPhase.hide()
 
         #HorizontalSpacer3(self.sampleCentreBox)
 
@@ -151,8 +151,8 @@ class HutchMenuBrick(BlissWidget):
 
         self.instanceSynchronize("")
 
-	self.resetMethods = None
-	self.successfulMethods = None
+        self.resetMethods = None
+        self.successfulMethods = None
 
     def enableAutoStartLoopCentring(self, enable):
         if self.minidiff is not None:
@@ -174,14 +174,14 @@ class HutchMenuBrick(BlissWidget):
                 self.disconnect(self.minidiff,PYSIGNAL('minidiffStateChanged'),self.miniDiffStateChanged)
                 self.disconnect(self.minidiff,PYSIGNAL('centringStarted'),self.centringStarted)
                 self.disconnect(self.minidiff,PYSIGNAL('centringSuccessful'),self.centringSuccessful)
-		self.disconnect(self.minidiff,PYSIGNAL('centringAccepted'),self.centringAccepted)
+                self.disconnect(self.minidiff,PYSIGNAL('centringAccepted'),self.centringAccepted)
                 self.disconnect(self.minidiff,PYSIGNAL('centringFailed'),self.centringFailed)
                 self.disconnect(self.minidiff,PYSIGNAL('centringMoving'),self.centringMoving)
                 self.disconnect(self.minidiff,PYSIGNAL('centringInvalid'),self.centringInvalid)
                 self.disconnect(self.minidiff,PYSIGNAL('centringSnapshots'),self.centringSnapshots)
                 self.disconnect(self.minidiff,PYSIGNAL('progressMessage'),self.miniDiffMessage)
-		self.disconnect(self.minidiff,PYSIGNAL('newAutomaticCentringPoint'),self.drawAutoCentringPoint)
-		self.disconnect(self.minidiff,PYSIGNAL('zoomMotorPredefinedPositionChanged'), self.zoomPositionChanged)
+                self.disconnect(self.minidiff,PYSIGNAL('newAutomaticCentringPoint'),self.drawAutoCentringPoint)
+                self.disconnect(self.minidiff,PYSIGNAL('zoomMotorPredefinedPositionChanged'), self.zoomPositionChanged)
             self.minidiff=self.getHardwareObject(newValue)
           
             if self.minidiff is not None:
@@ -190,26 +190,26 @@ class HutchMenuBrick(BlissWidget):
                 self.connect(self.minidiff,PYSIGNAL('minidiffStateChanged'),self.miniDiffStateChanged)
                 self.connect(self.minidiff,PYSIGNAL('centringStarted'),self.centringStarted)
                 self.connect(self.minidiff,PYSIGNAL('centringSuccessful'),self.centringSuccessful)
-		self.connect(self.minidiff,PYSIGNAL('centringAccepted'),self.centringAccepted)
+                self.connect(self.minidiff,PYSIGNAL('centringAccepted'),self.centringAccepted)
                 self.connect(self.minidiff,PYSIGNAL('centringFailed'),self.centringFailed)
                 self.connect(self.minidiff,PYSIGNAL('centringMoving'),self.centringMoving)
                 self.connect(self.minidiff,PYSIGNAL('centringInvalid'),self.centringInvalid)
                 self.connect(self.minidiff,PYSIGNAL('centringSnapshots'),self.centringSnapshots)
                 self.connect(self.minidiff,PYSIGNAL('progressMessage'),self.miniDiffMessage)
                 self.connect(self.minidiff,PYSIGNAL('newAutomaticCentringPoint'),self.drawAutoCentringPoint)
-		self.connect(self.minidiff,PYSIGNAL('zoomMotorPredefinedPositionChanged'),self.zoomPositionChanged)
+                self.connect(self.minidiff,PYSIGNAL('zoomMotorPredefinedPositionChanged'),self.zoomPositionChanged)
 
                 if self.minidiff.isReady():
                     self.miniDiffReady()
                 else:
                     self.miniDiffNotReady()
 
-	        self.resetMethods={self.minidiff.MANUAL3CLICK_MODE:self.manualCentreReset,
+                self.resetMethods={self.minidiff.MANUAL3CLICK_MODE:self.manualCentreReset,
                                    self.minidiff.C3D_MODE:self.automaticCentreReset}
-		                   #MiniDiff.MiniDiff.MOVE_TO_BEAM_MODE:self.moveToBeamReset}
+                                   #MiniDiff.MiniDiff.MOVE_TO_BEAM_MODE:self.moveToBeamReset}
                 self.successfulMethods={self.minidiff.MANUAL3CLICK_MODE:None,
                                         self.minidiff.C3D_MODE:self.automaticCentreSuccessful}
-            				#MiniDiff.MiniDiff.MOVE_TO_BEAM_MODE:self.moveToBeamSuccessful}
+                                            #MiniDiff.MiniDiff.MOVE_TO_BEAM_MODE:self.moveToBeamSuccessful}
             else:
                 self.miniDiffNotReady()
         elif propertyName=="samplechanger":
@@ -228,11 +228,11 @@ class HutchMenuBrick(BlissWidget):
             self.queue_hwobj = self.getHardwareObject(newValue)
             self.queue_hwobj.connect("queue_execution_finished", self.enable)
             self.queue_hwobj.connect("queue_stopped", self.enable)
-	elif propertyName=='useMDPhases':
-	    if newValue:
-	        self.buttonToogleMDPhase.show()
-	    else:
-		self.buttonToogleMDPhase.hide()
+        elif propertyName=='useMDPhases':
+            if newValue:
+                self.buttonToogleMDPhase.show()
+            else:
+                self.buttonToogleMDPhase.hide()
         else:
             BlissWidget.propertyChanged(self,propertyName,oldValue,newValue)
 
@@ -260,7 +260,7 @@ class HutchMenuBrick(BlissWidget):
             self.buttonReject.setPixmap(Icons.load(icons_list[4]))
         except IndexError:
             pass
-	try:
+        try:
             self.buttonToogleMDPhase.setPixmap(Icons.load(icons_list[5]))
         except IndexError:
             pass
@@ -412,10 +412,10 @@ class HutchMenuBrick(BlissWidget):
           self.insideDataCollection = False
           self.emit(PYSIGNAL("centringAccepted"), (state,centring_status))
 
-	beam_info = self.beamInfo.get_beam_info()	
-	if beam_info is not None:
-	    beam_info['size_x'] = beam_info['size_x'] * self.pixels_per_mm[0]
-	    beam_info['size_y'] = beam_info['size_y'] * self.pixels_per_mm[1]
+        beam_info = self.beamInfo.get_beam_info()
+        if beam_info is not None:
+            beam_info['size_x'] = beam_info['size_x'] * self.pixels_per_mm[0]
+            beam_info['size_y'] = beam_info['size_y'] * self.pixels_per_mm[1]
         self.emit(PYSIGNAL("newCentredPos"), (state, centring_status, beam_info))
 
         if self.queue_hwobj.is_executing():
@@ -577,8 +577,8 @@ class HutchMenuBrick(BlissWidget):
     # Handler for clicking the video when doing the 3-click centring
     def imageClicked(self,x,y,xi,yi):
         if self.currentCentring is not None\
-	and str(self.currentCentring.text()) == self.minidiff.MANUAL3CLICK_MODE\
-	and self.minidiff.isReady():
+        and str(self.currentCentring.text()) == self.minidiff.MANUAL3CLICK_MODE\
+        and self.minidiff.isReady():
             try:
                 points=self.minidiff.imageClicked(x,y,xi,yi)
             except StopIteration:
@@ -607,37 +607,37 @@ class HutchMenuBrick(BlissWidget):
         if signalName=='beamPositionChanged':
             if self.minidiff and self.beamInfo:
                 if self.minidiff.isReady():
-		    self.beam_position = self.beamInfo.get_beam_position()
+                    self.beam_position = self.beamInfo.get_beam_position()
                     self.emit(PYSIGNAL("beamPositionChanged"), (self.beam_position[0],\
-		                                                self.beam_position[1],
+                                                                self.beam_position[1],
                                                                 self.beam_size[0],\
-							        self.beam_size[1]))
+                                                                self.beam_size[1]))
         elif signalName=='calibrationChanged':
             if self.minidiff and self.minidiff.isReady():
                 try:
                     self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
                     self.emit(PYSIGNAL("calibrationChanged"), (1e3 / self.pixels_per_mm[0],\
-							       1e3 / self.pixels_per_mm[1]))     			
+                                                               1e3 / self.pixels_per_mm[1]))
                 except:
                     pass
 
     # Event when the minidiff is in ready state
     def miniDiffReady(self):
         try:
-	    self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
+            self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
         except:
             self.pixels_per_mm = [None, None] 
         
         if self.pixels_per_mm[0] is not None\
-	and self.pixels_per_mm[1] is not None:
-	    self.beam_position = self.beamInfo.get_beam_position()	
+        and self.pixels_per_mm[1] is not None:
+            self.beam_position = self.beamInfo.get_beam_position()
             self.beam_size = self.beamInfo.get_beam_size()
             self.sampleCentreBox.setEnabled(True)
             self.updateBeam()
             self.emit(PYSIGNAL("beamPositionChanged"), (self.beam_position[0],\
-							self.beam_position[1],
+                                                        self.beam_position[1],
                                                         self.beam_size[0],\
-						        self.beam_size[1]))
+                                                        self.beam_size[1]))
         else:
             self.miniDiffNotReady()
 
@@ -716,14 +716,14 @@ class HutchMenuBrick(BlissWidget):
             except AttributeError:
                 pass
             else:
-		self.emit(PYSIGNAL("calibrationChanged"), (self.__scaleX, self.__scaleY))
+                self.emit(PYSIGNAL("calibrationChanged"), (self.__scaleX, self.__scaleY))
                 self.updateBeam(force=True)
         except:
             logging.getLogger().exception("HutchMenuBrick: problem starting up display")
 
     def _drawBeam(self):
         if None in (self.beam_size, self.beam_shape):
-	    self.beam_position = self.beamInfo.get_beam_position()	
+            self.beam_position = self.beamInfo.get_beam_position()
             self.beam_size = self.beamInfo.get_beam_size()
          
         if True:
@@ -732,12 +732,12 @@ class HutchMenuBrick(BlissWidget):
             return
           if self.beam_shape == "rectangular":
             self.__rectangularBeam.setSlitboxSize(self.beam_size[0] * self.pixels_per_mm[0],\
-						  self.beam_size[1] * self.pixels_per_mm[1])
-	    self.__beam.hide()
+                                                  self.beam_size[1] * self.pixels_per_mm[1])
+            self.__beam.hide()
           else:
             self.__rectangularBeam.setSlitboxSize(0,0)
             self.__beam.setSize(self.beam_size[0] * self.pixels_per_mm[0],\
-				self.beam_size[1] * self.pixels_per_mm[1])
+                                self.beam_size[1] * self.pixels_per_mm[1])
             self.__beam.show()
 
     def updateBeam(self,force=False):
@@ -746,14 +746,14 @@ class HutchMenuBrick(BlissWidget):
               #  if not self.minidiff.isReady(): time.sleep(0.2)
               try:
                  self.__rectangularBeam.set_xMid_yMid(self.beam_position[0],
-						      self.beam_position[1])
+                                                      self.beam_position[1])
               except AttributeError:
                  pass
               try:
                 self.__beam.move(self.beam_position[0], self.beam_position[1])
-		self._drawBeam()
+                self._drawBeam()
                 #try:
-		#  self._updateBeam(self.beamInfo.get_beam_info())
+                #  self._updateBeam(self.beamInfo.get_beam_info())
                 #except:
                 #  logging.getLogger().exception("Could not get beam size: cannot display beam")
                 #  self.__beam.hide()
@@ -761,12 +761,12 @@ class HutchMenuBrick(BlissWidget):
                 pass
     
     def beamPosChanged(self, position):
-	self.beam_position = position
+        self.beam_position = position
         self.emit(PYSIGNAL("beamPositionChanged"), (self.beam_position[0],\
                                                     self.beam_position[1],
                                                     self.beam_size[0],\
                                                     self.beam_size[1]))
-	self.updateBeam(True)
+        self.updateBeam(True)
 
     def beamInfoChanged(self, beam_info):
         try:
@@ -779,7 +779,7 @@ class HutchMenuBrick(BlissWidget):
                                                     self.beam_position[1],
                                                     self.beam_size[0],\
                                                     self.beam_size[1]))
-    	self.updateBeam(True)
+        self.updateBeam(True)
 
     # Zoom changed: update pixels per mm
     def zoomPositionChanged(self,position,offset):
@@ -796,7 +796,7 @@ class HutchMenuBrick(BlissWidget):
             self.__scaleY = None
         else:
             if self.minidiff is not None:
-		self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
+                self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
                 if self.pixels_per_mm[0] is not None and self.pixels_per_mm[1] is not None:
                     pxsize_y = 1e-3 / self.pixels_per_mm[0]
                     pxsize_z = 1e-3 / self.pixels_per_mm[1]
@@ -812,8 +812,8 @@ class HutchMenuBrick(BlissWidget):
                     self.__scale.show()
             
     def toggleMDPhase(self):
-	if self.minidiff is not None:
-	    self.minidiff.togglePhase()
+        if self.minidiff is not None:
+            self.minidiff.togglePhase()
 
 class MenuButton(QToolButton):
     def __init__(self, parent, caption):

--- a/BlissFramework/Bricks/MicrodiffBrick.py
+++ b/BlissFramework/Bricks/MicrodiffBrick.py
@@ -17,7 +17,7 @@ SC_STATE_COLOR = { "FAULT": "red",
                    "UNKNOWN": "grey",
                    "CLOSE": "white",
                    "OFF": "white",
-		   "INIT": "yellow" }
+                   "INIT": "yellow" }
 
 
 class HorizontalSpacer(QWidget):

--- a/BlissFramework/Bricks/MotorPredefPosBrick.py
+++ b/BlissFramework/Bricks/MotorPredefPosBrick.py
@@ -118,7 +118,7 @@ class MotorPredefPosBrick(MotorWPredefinedPositionsBrick.MotorWPredefinedPositio
         if positions is None:
             positions=[]
 
-        list_index=self['listIndex']	  
+        list_index=self['listIndex']
         for p in positions:
             if list_index!=-1:
                 pos_list=p.split()
@@ -145,7 +145,7 @@ class MotorPredefPosBrick(MotorWPredefinedPositionsBrick.MotorWPredefinedPositio
             self.posButtonsPanel.show()
         else:
             self.lstPositions.show()
-            self.posButtonsPanel.hide()	      
+            self.posButtonsPanel.hide()
 
     def lstPositionsClicked(self, index):
         if index > 0:

--- a/BlissFramework/Bricks/MotorWPredefinedPositionsBrick.py
+++ b/BlissFramework/Bricks/MotorWPredefinedPositionsBrick.py
@@ -26,22 +26,22 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
         #
         self.addProperty('mnemonic', 'string', '')
         self.addProperty('showButtons', 'boolean', False)
-	self.addProperty('mode', 'combo', ('expert', 'user'), 'user')
+        self.addProperty('mode', 'combo', ('expert', 'user'), 'user')
  
         #
         # create GUI components
         #
         self.buttons = []
-	self.lblUsername = QLabel('motor :', self)
-	self.posButtonsPanel = QVButtonGroup(self)
+        self.lblUsername = QLabel('motor :', self)
+        self.posButtonsPanel = QVButtonGroup(self)
         self.lstPositions = QComboBox(self)
         self.expertPanel = QVBox(self)
-	self.motorWidget = MotorBrick.MotorBrick(self.expertPanel)
-	expertPanelButtonsBox = QGrid(2, Qt.Vertical, self.expertPanel)
+        self.motorWidget = MotorBrick.MotorBrick(self.expertPanel)
+        expertPanelButtonsBox = QGrid(2, Qt.Vertical, self.expertPanel)
         QLabel('pos. name :', expertPanelButtonsBox)
-	self.txtPositionName = QLineEdit(expertPanelButtonsBox)
+        self.txtPositionName = QLineEdit(expertPanelButtonsBox)
         QLabel('', expertPanelButtonsBox) #just a spacer in fact
-	self.cmdSetPosition = QPushButton('Set pos.', expertPanelButtonsBox)
+        self.cmdSetPosition = QPushButton('Set pos.', expertPanelButtonsBox)
 
         #
         # configure GUI components
@@ -50,12 +50,12 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
         QToolTip.add(self.lstPositions, 'Select a predefined position to move motor to')
         self.motorWidget['appearance'] = 'tiny'
         self.motorWidget['allowDoubleClick'] = True
-	self.posButtonsPanel.setInsideMargin(5)
-	self.posButtonsPanel.setInsideSpacing(0)
-	self.posButtonsPanel.setFrameStyle(QFrame.NoFrame)
-	self.posButtonsPanel.setExclusive(True)
-	expertPanelButtonsBox.setMargin(5)
-	expertPanelButtonsBox.setSpacing(5)        
+        self.posButtonsPanel.setInsideMargin(5)
+        self.posButtonsPanel.setInsideSpacing(0)
+        self.posButtonsPanel.setFrameStyle(QFrame.NoFrame)
+        self.posButtonsPanel.setExclusive(True)
+        expertPanelButtonsBox.setMargin(5)
+        expertPanelButtonsBox.setSpacing(5)
 
         #
         # connect signals / slots
@@ -94,7 +94,7 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
         
 
     def motorStateChanged(self, state):
-	s = state == self.motor.READY
+        s = state == self.motor.READY
         
         for button in self.buttons:
             button.setEnabled(s)
@@ -122,7 +122,7 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
         for i in range(1, self.lstPositions.count()):
             if self.lstPositions.text(i) == positionName:
                 self.lstPositions.setCurrentItem(i)
-		if len(self.buttons) > 0:
+                if len(self.buttons) > 0:
                     self.buttons[i - 1].setOn(True)
                 break
                 
@@ -140,10 +140,10 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
       self.cleanPositions()
 
       if self.motor is not None:
-	  if positions is None:
+          if positions is None:
               positions = self.motor.getPredefinedPositionsList()
-	  
-	  for p in positions:
+
+          for p in positions:
               self.lstPositions.insertItem(p)
 
               if self['showButtons']:
@@ -161,7 +161,7 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
           self.posButtonsPanel.show()
       else:
           self.lstPositions.show()
-          self.posButtonsPanel.hide()	      
+          self.posButtonsPanel.hide()
 
 
     def cmdSetPositionClicked(self):
@@ -172,26 +172,26 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
     def setMnemonic(self, mne):
         self.getProperty('mnemonic').setValue(mne)
         
-	if self.motor is not None:
+        if self.motor is not None:
             self.disconnect(self.motor, PYSIGNAL('stateChanged'), self.motorStateChanged)
             self.disconnect(self.motor, PYSIGNAL('newPredefinedPositions'), self.fillPositions)
             self.disconnect(self.motor, PYSIGNAL('predefinedPositionChanged'), self.predefinedPositionChanged)
 
         self.motor = self.getHardwareObject(mne)
         
-	if self.motor is not None:
+        if self.motor is not None:
             self.motorWidget.setMnemonic(mne)
             self.lblUsername.setText(self.motor.userName() + ' :')
 
             self.connect(self.motor, PYSIGNAL('newPredefinedPositions'), self.fillPositions)
-	    self.connect(self.motor, PYSIGNAL('stateChanged'), self.motorStateChanged)
+            self.connect(self.motor, PYSIGNAL('stateChanged'), self.motorStateChanged)
             self.connect(self.motor, PYSIGNAL('predefinedPositionChanged'), self.predefinedPositionChanged)
             
-	    self.fillPositions()
+            self.fillPositions()
  
             if self.motor.isReady():
                 self.predefinedPositionChanged(self.motor.getCurrentPositionName(), 0)
-	else:
+        else:
             self.lblUsername.setText('motor :')
             self.cleanPositions()
           
@@ -204,7 +204,7 @@ class MotorWPredefinedPositionsBrick(BlissWidget):
                 self.expertPanel.hide()
         elif property == 'showButtons':
             self.fillPositions()
-	elif property == 'mnemonic':	
+        elif property == 'mnemonic':
             self.setMnemonic(newValue)
         
         

--- a/BlissFramework/Bricks/MultiplePositionsCfgBrick.py
+++ b/BlissFramework/Bricks/MultiplePositionsCfgBrick.py
@@ -6,103 +6,103 @@ from BlissFramework.BaseComponents import BlissWidget
 __category__ = 'Motor'
 
 class ospDisplay(QHBox):
-	def __init__(self, *args):
-		QHBox.__init__(self, *args)
-		
-		self.radios = {}
-		self.buttonGroup = QVButtonGroup("", self)
-		self.vbox = QVBox(self)
-				
-	def setEquipment(self, equipment):			
-		self.vbox.close(True)
-		self.buttonGroup.close(True)
-		self.radios = {}
-		self.buttonGroup = QVButtonGroup("", self)
-		self.vbox = QVBox(self)
-		
-		self.buttonGroup.setTitle(equipment.username) 
-		for key in equipment.positionsIndex:
-			self.radios[key] = QRadioButton(key, self.buttonGroup)
+        def __init__(self, *args):
+                QHBox.__init__(self, *args)
 
-		for mot in equipment["motors"]:
-			MotorBrick.MotorBrick(self.vbox)["mnemonic"] = mot.name()
+                self.radios = {}
+                self.buttonGroup = QVButtonGroup("", self)
+                self.vbox = QVBox(self)
 
-		self.buttonGroup.show()
-		self.vbox.show()
-														
-	def positionClicked(self):
-		for name, radio in self.radios.items():
-			if radio.isChecked():
-				return name
-	
+        def setEquipment(self, equipment):
+                self.vbox.close(True)
+                self.buttonGroup.close(True)
+                self.radios = {}
+                self.buttonGroup = QVButtonGroup("", self)
+                self.vbox = QVBox(self)
+
+                self.buttonGroup.setTitle(equipment.username)
+                for key in equipment.positionsIndex:
+                        self.radios[key] = QRadioButton(key, self.buttonGroup)
+
+                for mot in equipment["motors"]:
+                        MotorBrick.MotorBrick(self.vbox)["mnemonic"] = mot.name()
+
+                self.buttonGroup.show()
+                self.vbox.show()
+
+        def positionClicked(self):
+                for name, radio in self.radios.items():
+                        if radio.isChecked():
+                                return name
+
 class MultiplePositionsCfgBrick(BlissWidget):
-	def __init__(self, *args):
-		BlissWidget.__init__(self, *args)
-		
-		self.hwro = None
-		self.defineSlot("setEquipment", ())
-		
+        def __init__(self, *args):
+                BlissWidget.__init__(self, *args)
+
+                self.hwro = None
+                self.defineSlot("setEquipment", ())
+
 #		self.addProperty('mode', 'combo', ("absolute", "relative"), "absolute")
-		self.addProperty('mnemonic', "string", "")
-		
-		QVBoxLayout(self)
-		self.panelDisplay = ospDisplay(self)
-		self.panel = QVBox(self)
-		self.WSetPosition = QPushButton("Set New Position", self.panel)
-		QObject.connect(self.WSetPosition, SIGNAL("clicked()"), \
-										self.setPosition)
+                self.addProperty('mnemonic', "string", "")
 
-		self.layout().addWidget(self.panelDisplay)
-		self.layout().addWidget(self.panel)		
+                QVBoxLayout(self)
+                self.panelDisplay = ospDisplay(self)
+                self.panel = QVBox(self)
+                self.WSetPosition = QPushButton("Set New Position", self.panel)
+                QObject.connect(self.WSetPosition, SIGNAL("clicked()"), \
+                                                                                self.setPosition)
 
-	def propertyChanged(self, property, oldValue, newValue):
-		if property == "mnemonic":
-		  #if oldValue != newValue:
-			self.setEquipment(newValue)
+                self.layout().addWidget(self.panelDisplay)
+                self.layout().addWidget(self.panel)
 
-	def setEquipment(self, equipment):
-		#if equipment != "":	
-		self.getProperty("mnemonic").setValue(equipment)
-		#self['mnemonic']=equipment
-		
-		self.hwro = self.getHardwareObject(equipment)
-		
-		if self.hwro is not None:
-			self.disconnect(self.hwro, PYSIGNAL('equipmentReady'), self.equipmentReady)
-			self.disconnect(self.hwro, PYSIGNAL('equipmentNotReady'), self.equipmentNotReady)
-			self.connect(self.hwro, PYSIGNAL('equipmentReady'), self.equipmentReady)
-			self.connect(self.hwro, PYSIGNAL('equipmentNotReady'), self.equipmentNotReady)
-			
-			self.panelDisplay.setEquipment(self.hwro)
-			
-			if self.hwro.isReady():
-				self.equipmentReady()
-				return
-		
-		self.equipmentNotReady()
-				
-	def equipmentReady(self):
-		self.setEnabled(True)
-		
-	def equipmentNotReady(self):
-		self.setEnabled(False)
-		
-	def setPosition(self):
-		positionname = 	self.panelDisplay.positionClicked()
-		if positionname is None:
-			QMessageBox.warning(self, "Warning", "Select a position first")
-			return
+        def propertyChanged(self, property, oldValue, newValue):
+                if property == "mnemonic":
+                  #if oldValue != newValue:
+                        self.setEquipment(newValue)
 
-		if self.hwro.mode == "absolute":
-			newValues = {}
-			for mot in self.hwro["motors"]:
-				newValues[mot.getMotorMnemonic()] = mot.getPosition()
-				
-			self.hwro.setNewPositions(positionname, newValues)
-		else:
-			for mot in self.hwro["motors"]:
-				pos = mot.getDialPosition()
-				mne = mot.getMotorMnemonic()
-				val = self.hwro.positions[positionname][mne] - pos
-				mot.setOffset(val)
-			
+        def setEquipment(self, equipment):
+                #if equipment != "":
+                self.getProperty("mnemonic").setValue(equipment)
+                #self['mnemonic']=equipment
+
+                self.hwro = self.getHardwareObject(equipment)
+
+                if self.hwro is not None:
+                        self.disconnect(self.hwro, PYSIGNAL('equipmentReady'), self.equipmentReady)
+                        self.disconnect(self.hwro, PYSIGNAL('equipmentNotReady'), self.equipmentNotReady)
+                        self.connect(self.hwro, PYSIGNAL('equipmentReady'), self.equipmentReady)
+                        self.connect(self.hwro, PYSIGNAL('equipmentNotReady'), self.equipmentNotReady)
+
+                        self.panelDisplay.setEquipment(self.hwro)
+
+                        if self.hwro.isReady():
+                                self.equipmentReady()
+                                return
+
+                self.equipmentNotReady()
+
+        def equipmentReady(self):
+                self.setEnabled(True)
+
+        def equipmentNotReady(self):
+                self.setEnabled(False)
+
+        def setPosition(self):
+                positionname =         self.panelDisplay.positionClicked()
+                if positionname is None:
+                        QMessageBox.warning(self, "Warning", "Select a position first")
+                        return
+
+                if self.hwro.mode == "absolute":
+                        newValues = {}
+                        for mot in self.hwro["motors"]:
+                                newValues[mot.getMotorMnemonic()] = mot.getPosition()
+
+                        self.hwro.setNewPositions(positionname, newValues)
+                else:
+                        for mot in self.hwro["motors"]:
+                                pos = mot.getDialPosition()
+                                mne = mot.getMotorMnemonic()
+                                val = self.hwro.positions[positionname][mne] - pos
+                                mot.setOffset(val)
+

--- a/BlissFramework/Bricks/MxLookupScanBrick.py
+++ b/BlissFramework/Bricks/MxLookupScanBrick.py
@@ -127,7 +127,7 @@ class MxLookupScanBrick(BaseGraphicScan) :
        points = self._graphicSelection.points()
        if len(points) == 3 and self._XSize and self._YSize:
              self._graphicSelection._xy_in_mm = numpy.array([(points[0][0] - self._beamx) * self._XSize,
-					                     (points[0][1] - self._beamy) * self._YSize])
+                                                             (points[0][1] - self._beamy) * self._YSize])
              table = self._widgetTree.child('__gridTable')
              dist = math.sqrt(((points[0][0] - points[1][0]) * self._XSize ) ** 2 + \
                                  ((points[0][1] - points[1][1]) * self._YSize) ** 2)
@@ -207,7 +207,7 @@ class MxLookupScanBrick(BaseGraphicScan) :
              xori = (self._graphicSelection._xy_in_mm[0] / self._XSize) + self._beamx
              yori = (self._graphicSelection._xy_in_mm[1] / self._YSize) + self._beamy
              #xori, yori = points[0]
-	     
+
              #p = numpy.array([[xori,yori],[xori + width,yori],[xori + width,yori + height]])
              p = numpy.array([[0,0],[width,0],[width,height]])
              

--- a/BlissFramework/Bricks/ProgressBarBrick.py
+++ b/BlissFramework/Bricks/ProgressBarBrick.py
@@ -9,17 +9,17 @@ class ProgressBarBrick(BlissWidget):
     def __init__(self, *args):
         BlissWidget.__init__(self, *args)
 
-	self.collect_hwobj = None	
+        self.collect_hwobj = None
 
-	self.addProperty('mnemonic', 'string', '')
+        self.addProperty('mnemonic', 'string', '')
         self.addProperty('appearance','combo',('simple', 'normal'),'normal')
         self.addProperty('title', 'string','')
         self.addProperty('timeFormat','string','%H:%M:%S')
 
         self.executing = None
-	self.time_total_sec = 0
-	self.time_remaining_sec = 0
-	self.time_format = None
+        self.time_total_sec = 0
+        self.time_remaining_sec = 0
+        self.time_format = None
         self.progress_task = None
 
         self.container_hbox = qt.QHGroupBox(self)
@@ -32,7 +32,7 @@ class ProgressBarBrick(BlissWidget):
         self.progressBar.setCenterIndicator(True)
         self.time_remaining_label = qt.QLabel('Remaining:',self.container_hbox)
         self.time_remaining_value_label = qt.QLabel('??:??:??',self.container_hbox)
-	
+
         qt.QVBoxLayout(self)
         self.setSizePolicy(qt.QSizePolicy.MinimumExpanding, qt.QSizePolicy.Fixed)
         self.layout().addWidget(self.container_hbox)
@@ -50,10 +50,10 @@ class ProgressBarBrick(BlissWidget):
         if not self.progress_task:
             self.setEnabled(True)
             self.progress_task = gevent.spawn(self.execute_progress)
-	
+
     def reset_progress(self):
         self.progressBar.reset()
-	self.time_total_value_label.setText(str(timedelta(seconds=0)))
+        self.time_total_value_label.setText(str(timedelta(seconds=0)))
         self.time_remaining_value_label.setText(str(timedelta(seconds=0)))
         if self.progress_task is not None:
             self.progress_task.kill()
@@ -64,14 +64,14 @@ class ProgressBarBrick(BlissWidget):
         self.reset_progress()
         self.time_total_sec = int(number_of_frames * exposure_time)
         self.progressBar.setTotalSteps(self.time_total_sec)
-	self.time_remaining_sec = self.time_total_sec
-	self.time_total_value_label.setText(str(timedelta(seconds = self.time_total_sec)))
+        self.time_remaining_sec = self.time_total_sec
+        self.time_total_value_label.setText(str(timedelta(seconds = self.time_total_sec)))
         self.setEnabled(True)
-	
+
     def execute_progress(self):
         while self.time_remaining_sec > -1:
-	    self.progressBar.setProgress(self.time_total_sec- self.time_remaining_sec)
-	    self.time_remaining_value_label.setText(str(timedelta(seconds = int(self.time_remaining_sec))))
+            self.progressBar.setProgress(self.time_total_sec- self.time_remaining_sec)
+            self.time_remaining_value_label.setText(str(timedelta(seconds = int(self.time_remaining_sec))))
             self.time_remaining_sec = self.time_remaining_sec -1
             time.sleep(1)
         self.setEnabled(False)
@@ -99,16 +99,16 @@ class ProgressBarBrick(BlissWidget):
             if newValue!="":
                 self.container_hbox.setTitle(newValue)
                 self.updateGeometry()      
-	elif propertyName == 'timeFormat':
-	    self.time_format=newValue
+        elif propertyName == 'timeFormat':
+            self.time_format=newValue
         elif propertyName == "mnemonic":
             if self.collect_hwobj is not None:
-		self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectNumberOfFrames'), self.set_progress_total_time)
-		self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectImageTaken'), self.start_progress)
-		self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectEnded'), self.stop_progress) 
+                self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectNumberOfFrames'), self.set_progress_total_time)
+                self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectImageTaken'), self.start_progress)
+                self.disconnect(self.collect_hwobj, qt.PYSIGNAL('collectEnded'), self.stop_progress)
             self.collect_hwobj = self.getHardwareObject(newValue)
             if self.collect_hwobj is not None:
-		self.connect(self.collect_hwobj, qt.PYSIGNAL('collectNumberOfFrames'), self.set_progress_total_time)
+                self.connect(self.collect_hwobj, qt.PYSIGNAL('collectNumberOfFrames'), self.set_progress_total_time)
                 self.connect(self.collect_hwobj, qt.PYSIGNAL('collectImageTaken'), self.start_progress)
                 self.connect(self.collect_hwobj, qt.PYSIGNAL('collectEnded'), self.stop_progress)
         else:

--- a/BlissFramework/Bricks/ProposalBrick2.py
+++ b/BlissFramework/Bricks/ProposalBrick2.py
@@ -38,7 +38,7 @@ class ProposalBrick2(BlissWidget):
         self.laboratory=None
         #self.sessionId=None
         self.inhouseProposal=None
-	self.loginType = "proposal"
+        self.loginType = "proposal"
 
         self.instanceServer=None
 
@@ -78,12 +78,12 @@ class ProposalBrick2(BlissWidget):
         self.propNumber.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.MinimumExpanding)
         self.propNumber.setPaletteBackgroundColor(widget_colors.LIGHT_RED)
         self.propNumber.setFixedWidth(50)
-	
+
         self.userName=QLineEdit(self.loginBox)
         self.userName.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.MinimumExpanding)
         self.userName.setPaletteBackgroundColor(widget_colors.LIGHT_RED)
         self.userName.setFixedWidth(75)
-	self.userName.hide()
+        self.userName.hide()
 
         password_label=QLabel("   Password: ",self.loginBox)
         self.propPassword=QLineEdit(self.loginBox)
@@ -241,8 +241,8 @@ class ProposalBrick2(BlissWidget):
         self.user_group_ledit.hide()
         self.user_group_save_button.hide()
        
-	#resets active proposal
-	self.resetProposal()
+        #resets active proposal
+        self.resetProposal()
  
         #self.proposalLabel.setText(ProposalBrick2.NOBODY_STR)
         #QToolTip.add(self.proposalLabel,"")
@@ -256,7 +256,7 @@ class ProposalBrick2(BlissWidget):
         self.session_hwobj.proposal_code = None
         self.session_hwobj.session_id = None
         self.session_hwobj.proposal_id = None
-        self.session_hwobj.proposal_number = None 	
+        self.session_hwobj.proposal_number = None
 
     # Sets the current session; changes from login mode to logout mode
     def setProposal(self,proposal,person,laboratory,session,localcontact):
@@ -474,15 +474,15 @@ class ProposalBrick2(BlissWidget):
 
         propType=str(self.propType.currentText())
         propNumber=str(self.propNumber.text()) or ""
-	userName = str(self.userName.text()) or ""
+        userName = str(self.userName.text()) or ""
         password=str(self.propPassword.text())
         self.propPassword.setText("")
 
-	if self.loginType == "proposal":
-	    loginID = "%s%s" % (propType,propNumber)
-	else:
-	    loginID= userName
-	
+        if self.loginType == "proposal":
+            loginID = "%s%s" % (propType,propNumber)
+        else:
+            loginID= userName
+
         # try local login if userID is empty
         if propNumber =="" and userName == "":
             if self.localLogin is None:
@@ -512,19 +512,19 @@ class ProposalBrick2(BlissWidget):
         if self.dbConnection == None:
             return self.refuseLogin(False,'Not connected to the ISPyB database, unable to get proposal.')
          
-	loginRes=self.dbConnection.login(loginID,password)
-	try:
+        loginRes=self.dbConnection.login(loginID,password)
+        try:
             login_ok=(loginRes['status']['code']=='ok')
         except KeyError:
             login_ok=False
         if not login_ok:
-	    if loginRes['status']['code'] == 'ispybDown':
-		self.ispybDown()
-		return
+            if loginRes['status']['code'] == 'ispybDown':
+                self.ispybDown()
+                return
             else:
                 self.refuseLogin(False, loginRes['status']['msg'])
-	else:
-	    # login succeed but without a scheduled session, a newSession is created instead. Ask the user to accep the new session
+        else:
+            # login succeed but without a scheduled session, a newSession is created instead. Ask the user to accep the new session
             if loginRes['session']['new_session_flag']:
                 if not  self.askForNewSession():
                     return self.refuseLogin(None,None)
@@ -546,8 +546,8 @@ class ProposalBrick2(BlissWidget):
             self.localLogin=self.getHardwareObject(newValue)
         elif propertyName=='dbConnection':
             self.dbConnection = self.getHardwareObject(newValue)
-	    logging.getLogger().info("dbconnection is %s", str(newValue))
-	    self.updateLoginID()
+            logging.getLogger().info("dbconnection is %s", str(newValue))
+            self.updateLoginID()
         elif propertyName=='instanceServer':
             if self.instanceServer is not None:
                 self.disconnect(self.instanceServer,PYSIGNAL('passControl'), self.passControl)
@@ -572,18 +572,18 @@ class ProposalBrick2(BlissWidget):
             BlissWidget.propertyChanged(self,propertyName,oldValue,newValue)
 
     def updateLoginID(self):
-	if self.loginType == self.dbConnection.loginType:
-	    return
+        if self.loginType == self.dbConnection.loginType:
+            return
         self.loginType = self.dbConnection.loginType
         if self.loginType == "proposal":
-	    self.code_label.setText("  Code: ")
+            self.code_label.setText("  Code: ")
             self.userName.hide()
-	    self.propType.show()
-	    self.dash_label.show()
-	    self.propNumber.show()
-	else:
+            self.propType.show()
+            self.dash_label.show()
+            self.propNumber.show()
+        else:
             self.code_label.setText("  User ID: ")
-	    self.userName.show()
+            self.userName.show()
             self.propType.hide()
             self.dash_label.hide()
             self.propNumber.hide()

--- a/BlissFramework/Bricks/Qt4_BeamAlignBrick.py
+++ b/BlissFramework/Bricks/Qt4_BeamAlignBrick.py
@@ -43,7 +43,7 @@ class Qt4_BeamAlignBrick(BlissWidget):
         Descript. :
         """
         BlissWidget.__init__(self, *args)
-	
+
         # Hardware objects ----------------------------------------------------
         self.beam_align_hwobj = None
 

--- a/BlissFramework/Bricks/Qt4_BeamSizeBrick.py
+++ b/BlissFramework/Bricks/Qt4_BeamSizeBrick.py
@@ -67,7 +67,7 @@ class Qt4_BeamSizeBrick(BlissWidget):
         Descript. :
         """
         BlissWidget.__init__(self, *args)
-	
+
         # Hardware objects ----------------------------------------------------
         self.beam_info_hwobj = None
 

--- a/BlissFramework/Bricks/Qt4_CRLBrick.py
+++ b/BlissFramework/Bricks/Qt4_CRLBrick.py
@@ -42,7 +42,7 @@ class Qt4_CRLBrick(BlissWidget):
         Descript. :
         """
         BlissWidget.__init__(self, *args)
-	
+
         # Hardware objects ----------------------------------------------------
         self.crl_hwobj = None
 
@@ -102,7 +102,7 @@ class Qt4_CRLBrick(BlissWidget):
         self.crl_value_table.horizontalHeader().hide()
         self.crl_value_table.setRowHeight(0, 20)
         self.crl_value_table.setFixedHeight(26)
-	self.crl_value_table.setShowGrid(True)
+        self.crl_value_table.setShowGrid(True)
 
         #self.set_according_to_energy_button.setIcon(Qt4_Icons.load_icon("Up2"))
         #self.set_out_button.setIcon(Qt4_Icons.load_icon("Up2"))

--- a/BlissFramework/Bricks/Qt4_DetectorStatusBrick.py
+++ b/BlissFramework/Bricks/Qt4_DetectorStatusBrick.py
@@ -119,7 +119,7 @@ class Qt4_DetectorStatusBrick(BlissWidget):
                 self.disconnect(self.detector_hwobj,
                                 'frameRateChanged',
                                 self.frame_rate_changed)
-	    self.detector_hwobj = self.getHardwareObject(new_value)
+            self.detector_hwobj = self.getHardwareObject(new_value)
             if self.detector_hwobj is not None:
                 self.connect(self.detector_hwobj,
                              'temperatureChanged',

--- a/BlissFramework/Bricks/Qt4_ProgressBarBrick.py
+++ b/BlissFramework/Bricks/Qt4_ProgressBarBrick.py
@@ -42,7 +42,7 @@ class Qt4_ProgressBarBrick(BlissWidget):
         BlissWidget.__init__(self, *args)
 
         # Hardware objects ----------------------------------------------------
-	self.collect_hwobj = None	
+        self.collect_hwobj = None
 
         # Internal values -----------------------------------------------------
         self.number_of_steps = 0

--- a/BlissFramework/Bricks/Qt4_ProposalBrick2.py
+++ b/BlissFramework/Bricks/Qt4_ProposalBrick2.py
@@ -319,7 +319,7 @@ class Qt4_ProposalBrick2(BlissWidget):
         #self.title_label.hide()
         self.user_group_widget.hide()
        
-	#resets active proposal
+        #resets active proposal
         self.resetProposal()
  
         #self.proposalLabel.setText(Qt4_ProposalBrick2.NOBODY_STR)
@@ -337,7 +337,7 @@ class Qt4_ProposalBrick2(BlissWidget):
         self.session_hwobj.proposal_code = None
         self.session_hwobj.session_id = None
         self.session_hwobj.proposal_id = None
-        self.session_hwobj.proposal_number = None 	
+        self.session_hwobj.proposal_number = None
 
     # Sets the current session; changes from login mode to logout mode
     def setProposal(self, proposal, session):

--- a/BlissFramework/Bricks/Qt4_SlitsBrick.py
+++ b/BlissFramework/Bricks/Qt4_SlitsBrick.py
@@ -105,7 +105,7 @@ class Qt4_SlitsBrick(BlissWidget):
         self.stop_hor_button.setEnabled(False)
         self.stop_hor_button.setFixedWidth(27)
 
-	#Vertical gap
+        #Vertical gap
         ver_label = QLabel("Vertical:", self.main_gbox)
         self.current_ver_pos_ledit = QLineEdit(self.main_gbox)
         self.current_ver_pos_ledit.setAlignment(Qt.AlignRight)
@@ -263,7 +263,7 @@ class Qt4_SlitsBrick(BlissWidget):
         if newGap[1] is None:
             self.current_ver_pos_ledit.setText("-")
         #elif newGap[1] < 0:
-	#     self.current_ver_pos_ledit.setText("-")
+        #     self.current_ver_pos_ledit.setText("-")
         else:
             gap_str = str(newGap[1] * 1000)
             self.current_ver_pos_ledit.setText('%d %sm' % (newGap[1] * 1000, unichr(956)))

--- a/BlissFramework/Bricks/SOLEIL/EnergyScanBrickPX2.py
+++ b/BlissFramework/Bricks/SOLEIL/EnergyScanBrickPX2.py
@@ -24,7 +24,7 @@ class QSpecScan(QObject, SpecScan.SpecScanA):
         self.graph_data = None
 
     def newScanPoint(self, i, x, y):
-	# if x is in keV, transform into eV otherwise let it like it is
+        # if x is in keV, transform into eV otherwise let it like it is
         self.x.append(x < 1000 and x*1000.0 or x)
         self.y.append(y)
 
@@ -190,7 +190,7 @@ class EnergyScanBrickPX2(BlissWidget):
         self.instanceSynchronize("parametersBox","prefixInput","directoryInput","peakInput","inflectionInput","remoteInput","remote2Input")
 
         self.choochGraphs = QtBlissGraph(self)
-	self.choochGraphs.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed) 
+        self.choochGraphs.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
 
         QVBoxLayout(self)
         self.layout().addWidget(self.parametersBox)
@@ -337,8 +337,8 @@ class EnergyScanBrickPX2(BlissWidget):
             self.clearEnergies()
             self.energyScan = self.getHardwareObject(newValue)
             if self.energyScan is not None:
-		self.scanObject = None
-		#try:
+                self.scanObject = None
+                #try:
                 #  specversion = self.energyScan.getCommandObject("doEnergyScan").specVersion
                 #except:
                 #  logging.getLogger().exception("%s: could not get spec version from Energy Scan Hardware Object", self.name())

--- a/BlissFramework/Bricks/SOLEIL/HutchMenuBrickPX1.py
+++ b/BlissFramework/Bricks/SOLEIL/HutchMenuBrickPX1.py
@@ -24,6 +24,7 @@ class HutchMenuBrickPX1(HutchMenuBrick.HutchMenuBrick):
               try:
                 self.__beam.move(beam_x, beam_y)
                 try:
+                    # TODO FIXME ERROR: get_beam_info is a function - this cannot be right
                   get_beam_info = self.minidiff.getBeamInfo #getCommandObject("getBeamInfo")
                   if force or get_beam_info: #.isSpecReady():
                       self._updateBeam({"size_x":0.045, "size_y":0.025, "shape": "rectangular"})

--- a/BlissFramework/Bricks/SOLEIL/NamedStateBrick.py
+++ b/BlissFramework/Bricks/SOLEIL/NamedStateBrick.py
@@ -23,7 +23,7 @@ class NamedStateBrick(BaseComponents.BlissWidget):
         #
         # create GUI components
         #
-	self.lblUsername = QLabel('', self)
+        self.lblUsername = QLabel('', self)
         self.lstStates = QComboBox(self)
 
         #
@@ -64,7 +64,7 @@ class NamedStateBrick(BaseComponents.BlissWidget):
 
         logging.debug("Changing property for NamedStateBrick %s = %s" % (property,newValue))
 
-	if property == 'mnemonic':	
+        if property == 'mnemonic':
 
             self.setMnemonic(newValue)
 
@@ -83,14 +83,14 @@ class NamedStateBrick(BaseComponents.BlissWidget):
         
     def setMnemonic(self,mne):
         
-	if self.hwo is not None:
+        if self.hwo is not None:
             self.disconnect(self.hwo, PYSIGNAL('stateChanged'), self.stateChanged)
             self.disconnect(self.hwo, PYSIGNAL('hardwareStateChanged'), self.hdwStateChanged)
             self.disconnect(self.hwo, PYSIGNAL('newStateList'), self.stateList)
 
         self.hwo = self.getHardwareObject(mne)
         
-	if self.hwo is not None:
+        if self.hwo is not None:
 
             username = self.hwo.getUserName()
             if username.strip() != "":
@@ -98,16 +98,16 @@ class NamedStateBrick(BaseComponents.BlissWidget):
                 username += " :" 
             self.lblUsername.setText(username + ' :')
 
-	    self.fillStates()
+            self.fillStates()
 
             self.connect(self.hwo, PYSIGNAL('newStateList'), self.fillStates)
-	    self.connect(self.hwo, PYSIGNAL('stateChanged'), self.stateChanged)
-	    self.connect(self.hwo, PYSIGNAL('hardwareStateChanged'), self.hdwStateChanged)
+            self.connect(self.hwo, PYSIGNAL('stateChanged'), self.stateChanged)
+            self.connect(self.hwo, PYSIGNAL('hardwareStateChanged'), self.hdwStateChanged)
             
  
             if self.hwo.isReady():
                 self.stateChanged(self.hwo.getCurrentState())
-	else:
+        else:
             self.lblUsername.setText('State Object:')
             self.cleanStates()
           

--- a/BlissFramework/Bricks/SOLEIL/SoleilBeamStopBrick.py
+++ b/BlissFramework/Bricks/SOLEIL/SoleilBeamStopBrick.py
@@ -230,4 +230,4 @@ class SoleilBeamStopBrick(DuoStateBrick):
     def stopClicked(self):
         for motor in self.beamstop.motors:
             self.beamstop.motors[motor].stop()
-	return
+        return

--- a/BlissFramework/Bricks/SOLEIL/SoleilHutchMenuBrick.py
+++ b/BlissFramework/Bricks/SOLEIL/SoleilHutchMenuBrick.py
@@ -500,10 +500,10 @@ class SoleilHutchMenuBrick(BlissWidget):
           self.emit(PYSIGNAL("centringAccepted"), (state,centring_status))
 
         if self.beamInfo is not None:
-	   beam_info = self.beamInfo.get_beam_info()	
-	   if beam_info is not None:
-	       beam_info['size_x'] = beam_info['size_x'] * self.pixels_per_mm[0]
-	       beam_info['size_y'] = beam_info['size_y'] * self.pixels_per_mm[1]
+           beam_info = self.beamInfo.get_beam_info()
+           if beam_info is not None:
+               beam_info['size_x'] = beam_info['size_x'] * self.pixels_per_mm[0]
+               beam_info['size_y'] = beam_info['size_y'] * self.pixels_per_mm[1]
            self.emit(PYSIGNAL("newCentredPos"), (state, centring_status, beam_info))
            #self.emit(PYSIGNAL("newCentredPos"), (state, centring_status))
 
@@ -700,12 +700,12 @@ class SoleilHutchMenuBrick(BlissWidget):
         print "..... HutchMenuBrick:connectNotify  ", signalName
         if signalName=='beamPositionChanged':
             if self.minidiff and self.minidiff.isReady() and self.beamInfo is not None:
-		self.beam_position = self.beamInfo.get_beam_position()
-		self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
+                self.beam_position = self.beamInfo.get_beam_position()
+                self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
                 self.emit(PYSIGNAL("beamPositionChanged"), (self.beam_position[0],\
-							    self.beam_position[1],
+                                                            self.beam_position[1],
                                                             self.beam_size[0],\
-							    self.beam_size[1]))
+                                                            self.beam_size[1]))
             #if self.minidiff and self.minidiff.isReady():
             #    beam_xc = self.minidiff.getBeamPosX()
             #    beam_yc = self.minidiff.getBeamPosY()
@@ -727,7 +727,7 @@ class SoleilHutchMenuBrick(BlissWidget):
         try:
             self.pixels_per_mm = self.minidiff.get_pixels_per_mm()
             if self.beamInfo is not None:
-                self.beam_position = self.beamInfo.get_beam_position()	
+                self.beam_position = self.beamInfo.get_beam_position()
         except:
             import traceback
             logging.getLogger().error("error on minidiff ready %s", traceback.format_exc())
@@ -865,7 +865,7 @@ class SoleilHutchMenuBrick(BlissWidget):
           else:
             self.__rectangularBeam.setSlitboxSize(0,0)
             self.__beam.setSize(self.beam_size[0] * self.pixels_per_mm[0],\
-				self.beam_size[1] * self.pixels_per_mm[1])
+                                self.beam_size[1] * self.pixels_per_mm[1])
             logging.getLogger().info("beam drawn with size %s " % str(self.beam_size))
             #self.__beam.setSize(bx*pxmmy, by*pxmmz)
             self.__beam.show()

--- a/BlissFramework/Bricks/SOLEIL/SoleilMachCurrentBrick.py
+++ b/BlissFramework/Bricks/SOLEIL/SoleilMachCurrentBrick.py
@@ -116,7 +116,7 @@ class SoleilMachCurrentBrick(BaseComponents.BlissWidget):
             self.mode.setText("<i>%s</i>" % fillmode)
 
         #<modif pierre.L 18.03.08
-	#try:
+        #try:
         #    refill_secs=int(refill)
         #    if refill_secs>=0:
         #        ts=time.gmtime(refill_secs)

--- a/BlissFramework/Bricks/SOLEIL/SoleilScanPlotBrick.py
+++ b/BlissFramework/Bricks/SOLEIL/SoleilScanPlotBrick.py
@@ -17,7 +17,7 @@ class SoleilScanPlotBrick(BlissWidget):
         BlissWidget.__init__(self, *args)
 
         self.defineSlot('newScan', ())
-	
+
         self.defineSlot('newScanPoint',())
 
         self.scanObject = None

--- a/BlissFramework/Bricks/ShutterBrick.py
+++ b/BlissFramework/Bricks/ShutterBrick.py
@@ -43,10 +43,10 @@ class ShutterBrick(SynopticBrick.SynopticBrick):
 
 
     def updateGUI(self):
-	self.shutter = self.getHardwareObject(self['mnemonic'])
+        self.shutter = self.getHardwareObject(self['mnemonic'])
 
         if self.shutter is not None:
-	    if self.isRunning():
+            if self.isRunning():
                 self.setEnabled(True)
 
             self.shutterStateChanged(self.shutter.getShutterState())

--- a/BlissFramework/Bricks/SpecValueBrick.py
+++ b/BlissFramework/Bricks/SpecValueBrick.py
@@ -241,7 +241,7 @@ class SpecValueBrick(BlissWidget):
         # to manage associative array, from the xml file use the
         # syntax MYARRAY/avalue to access the SPEC variable MYARRAY["avalue"].
         #if type(value) is  types.DictionaryType:
-	#    val = value[value.keys()[0]]
+        #    val = value[value.keys()[0]]
         #    if type(val) is  types.DictionaryType:
         #        val = val[val.keys()[0]]
         if self.varType in ["motor", "float"]:

--- a/BlissFramework/Bricks/SynopticEquipmentMotorsBrick.py
+++ b/BlissFramework/Bricks/SynopticEquipmentMotorsBrick.py
@@ -88,7 +88,7 @@ class SynopticEquipmentMotorsBrick(SynopticBrick.SynopticBrick):
                     newMotorWidget.getProperty('formatString').setValue(self.getProperty('formatString').getUserValue())
                     newMotorWidget.getProperty('allowConfigure').setValue(True)
                     newMotorWidget.getProperty('allowDoubleClick').setValue(self['allowControl'])
-		    newMotorWidget.getProperty('dialogCaption').setValue("%s [%s] - %s" % (self['title'], motorCategory, motor.userName()))
+                    newMotorWidget.getProperty('dialogCaption').setValue("%s [%s] - %s" % (self['title'], motorCategory, motor.userName()))
                     newMotorWidget.readProperties()
 
                     if self.isRunning():

--- a/BlissFramework/Bricks/SynopticMotorWPredefinedPositionsBrick.py
+++ b/BlissFramework/Bricks/SynopticMotorWPredefinedPositionsBrick.py
@@ -18,17 +18,17 @@ class SynopticMotorWPredefinedPositionsBrick(SynopticBrick.SynopticBrick):
         self.buttons = []
 
         self.expertPanel = QVBox(self.containerBox)
-	self.motorWidget = MotorBrick.MotorBrick(self.expertPanel)
-	expertPanelButtonsBox = QGrid(2, Qt.Vertical, self.expertPanel)
+        self.motorWidget = MotorBrick.MotorBrick(self.expertPanel)
+        expertPanelButtonsBox = QGrid(2, Qt.Vertical, self.expertPanel)
         QLabel('pos. name :', expertPanelButtonsBox)
-	self.txtPositionName = QLineEdit(expertPanelButtonsBox)
+        self.txtPositionName = QLineEdit(expertPanelButtonsBox)
         QLabel('', expertPanelButtonsBox) #just a spacer in fact
-	self.cmdSetPosition = QPushButton('Set pos.', expertPanelButtonsBox)
+        self.cmdSetPosition = QPushButton('Set pos.', expertPanelButtonsBox)
                             
         self.motorWidget['appearance'] = 'tiny'
         self.motorWidget['allowDoubleClick'] = True
-	expertPanelButtonsBox.setMargin(5)
-	expertPanelButtonsBox.setSpacing(5)
+        expertPanelButtonsBox.setMargin(5)
+        expertPanelButtonsBox.setSpacing(5)
 
         QObject.connect(self.cmdSetPosition, SIGNAL('clicked()'), self.cmdSetPositionClicked)
 
@@ -106,7 +106,7 @@ class SynopticMotorWPredefinedPositionsBrick(SynopticBrick.SynopticBrick):
 
         
     def motorStateChanged(self, state):
-	s = state == self.motor.READY
+        s = state == self.motor.READY
         
         for button in self.buttons:
             button.setEnabled(s)

--- a/BlissFramework/Bricks/ValueDisplayBrick.py
+++ b/BlissFramework/Bricks/ValueDisplayBrick.py
@@ -46,8 +46,8 @@ class ValueDisplayBrick(SynopticBrick.SynopticBrick):
             elif type(value) == types.StringType:
                 svalue = str(value)
             else:
-				svalue = '-'
-				logging.getLogger().error('%s: cannot display value, unknown type %s', str(self.name()), type(value))
+                svalue = '-'
+                logging.getLogger().error('%s: cannot display value, unknown type %s', str(self.name()), type(value))
   
         self.lcdValue.display(svalue)
         self.lblValue.setText('<nobr><font face="courier">%s</font></nobr>' % svalue)

--- a/BlissFramework/Bricks/XRFSpectrumParametersBrick.py
+++ b/BlissFramework/Bricks/XRFSpectrumParametersBrick.py
@@ -16,7 +16,7 @@ class XRFSpectrumParametersBrick(BaseComponents.BlissWidget):
         self.addProperty('xrf-spectrum', 'string', '')        
         self.addProperty("session", "string", "/session")
         self.session_hwobj = None
-	self.xrf_spectrum_hwobj = None
+        self.xrf_spectrum_hwobj = None
         
         # Layout
         main_layout = qt.QVBoxLayout(self)
@@ -38,8 +38,8 @@ class XRFSpectrumParametersBrick(BaseComponents.BlissWidget):
         Overriding BaseComponents.BlissWidget (propertyChanged object) 
         run method.
         """
-	if property_name == 'xrf-spectrum':
-	    self.xrf_spectrum_hwobj = self.getHardwareObject(new_value) 	 
+        if property_name == 'xrf-spectrum':
+            self.xrf_spectrum_hwobj = self.getHardwareObject(new_value)
             self.xrf_spectrum_widget.set_xrf_spectrum_hwobj(self.getHardwareObject(new_value))
         elif property_name == 'session':
             self.session_hwobj = self.getHardwareObject(new_value)

--- a/BlissFramework/Bricks/ZapScanBrick.py
+++ b/BlissFramework/Bricks/ZapScanBrick.py
@@ -119,13 +119,13 @@ class ZapScanBrick(BaseComponents.BlissWidget):
     def propertyChanged(self, property, oldValue, newValue):
         if property == 'mnemonic':
             scan = self.getHardwareObject(newValue)
-       	    self.setScan(scan)
+            self.setScan(scan)
         elif property == 'equipment':
             self.equipmentMnemonicChanged()
 
 
     def setMnemonic(self, mne):
-	self['mnemonic'] = mne
+        self['mnemonic'] = mne
 
 
     def setScan(self, scan):

--- a/BlissFramework/Bricks/widgets/Qt4_scan_plot_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_scan_plot_widget.py
@@ -104,12 +104,12 @@ class ScanPlotWidget(QWidget):
 
     def plot_results(self, pk, fppPeak, fpPeak, ip, fppInfl, fpInfl,
                         rm, chooch_graph_x, chooch_graph_y1, chooch_graph_y2, title):
-	self.graph.clearcurves()	
+        self.graph.clearcurves()
         self.graph.setTitle(title)
         self.graph.newcurve("spline", chooch_graph_x, chooch_graph_y1)
         self.graph.newcurve("fp", chooch_graph_x, chooch_graph_y2)
         self.graph.replot()
-	self.isScanning = False
+        self.isScanning = False
 
     def plot_scan_curve(self, scan_data):
         self.graph.clearcurves()

--- a/BlissFramework/Bricks/widgets/confirm_dialog_widget_vertical_layout.py
+++ b/BlissFramework/Bricks/widgets/confirm_dialog_widget_vertical_layout.py
@@ -45,18 +45,18 @@ class ConfirmDialogWidgetVerticalLayout(QWidget):
         cbx_layout.addWidget(self.skip_existing_images_cbx)
 
 
-	take_snapshots_layout = QHBoxLayout(None,0,3,"snapshots_layout")
+        take_snapshots_layout = QHBoxLayout(None,0,3,"snapshots_layout")
 
-	self.take_snapshots_label = QLabel(self.summary_gbox, "take_snaphots_label")
-	take_snapshots_layout.addWidget(self.take_snapshots_label)
+        self.take_snapshots_label = QLabel(self.summary_gbox, "take_snaphots_label")
+        take_snapshots_layout.addWidget(self.take_snapshots_label)
 
         self.take_snapshots_cbox = QComboBox(self.summary_gbox, "take_snapshosts_cbox")
-	take_snapshots_layout.addWidget(self.take_snapshots_cbox)
+        take_snapshots_layout.addWidget(self.take_snapshots_cbox)
 
-	take_snapshots_hspacer = QSpacerItem(1,20,QSizePolicy.Expanding,QSizePolicy.Minimum)
+        take_snapshots_hspacer = QSpacerItem(1,20,QSizePolicy.Expanding,QSizePolicy.Minimum)
         take_snapshots_layout.addItem(take_snapshots_hspacer)
 
-	cbx_layout.addLayout(take_snapshots_layout)
+        cbx_layout.addLayout(take_snapshots_layout)
 
         self.missing_one_cbx = QCheckBox(self.summary_gbox,"missing_one_cbx")
         cbx_layout.addWidget(self.missing_one_cbx)
@@ -98,12 +98,12 @@ class ConfirmDialogWidgetVerticalLayout(QWidget):
         self.summary_label.setText(self.__tr("<summary label>"))
         self.force_dark_cbx.setText(self.__tr("Force dark current"))
         self.skip_existing_images_cbx.setText(self.__tr("Skip already collected images"))
-	self.take_snapshots_label.setText(self.__tr("Number of crystal snapshots:"))
+        self.take_snapshots_label.setText(self.__tr("Number of crystal snapshots:"))
 
-	self.take_snapshots_cbox.clear()
+        self.take_snapshots_cbox.clear()
         for i in self.snapshots_list:
           self.take_snapshots_cbox.insertItem(self.__tr(str(i)))
-		
+
         self.missing_one_cbx.setText(self.__tr("Missing box one"))
         self.missing_two_cbx.setText(self.__tr("Missing box two"))
         self.file_list_view.header().setLabel(0,self.__tr("Sample"))

--- a/BlissFramework/Bricks/widgets/create_xrf_scan_widget.py
+++ b/BlissFramework/Bricks/widgets/create_xrf_scan_widget.py
@@ -15,7 +15,7 @@ class CreateXRFScanWidget(CreateTaskBase):
     def __init__(self, parent = None, name = None, fl = 0):
         CreateTaskBase.__init__(self, parent, name, fl, 'XRF-scan')
 
-	self.count_time = None
+        self.count_time = None
 
         # Data attributes
         self.init_models()
@@ -30,12 +30,12 @@ class CreateXRFScanWidget(CreateTaskBase):
                                                data_model = self._path_template,
                                                layout = 'vertical')
 
-	parameters_hor_gbox = qt.QHGroupBox('Parameters', self)
+        parameters_hor_gbox = qt.QHGroupBox('Parameters', self)
 
-	self.count_time_label = qt.QLabel("Count time", parameters_hor_gbox)
+        self.count_time_label = qt.QLabel("Count time", parameters_hor_gbox)
         self.count_time_label.setFixedWidth(83) 
 
-	self.count_time_ledit = qt.QLineEdit("1.0", parameters_hor_gbox,"count_time_ledit")
+        self.count_time_ledit = qt.QLineEdit("1.0", parameters_hor_gbox,"count_time_ledit")
         self.count_time_ledit.setFixedWidth(50)
 
         self.xrfscan_mib.bind_value_update('count_time',
@@ -45,8 +45,8 @@ class CreateXRFScanWidget(CreateTaskBase):
         spacer = qt.QWidget(parameters_hor_gbox)
         spacer.setSizePolicy(qt.QSizePolicy.Expanding,qt.QSizePolicy.Fixed)
 
-	v_layout.addWidget(self._data_path_gbox)
-	v_layout.addWidget(parameters_hor_gbox)
+        v_layout.addWidget(self._data_path_gbox)
+        v_layout.addWidget(parameters_hor_gbox)
         v_layout.addStretch()
 
         self.connect(self._data_path_widget.data_path_widget_layout.child('run_number_ledit'),
@@ -98,11 +98,11 @@ class CreateXRFScanWidget(CreateTaskBase):
                 isinstance(shape, shape_history.CanvasGrid)):
                 result = False
 
-	self.count_time = None
-	try:
-	   self.count_time = float(str(self.count_time_ledit.text()))
-	except:
-	   logging.getLogger("user_level_log").\
+        self.count_time = None
+        try:
+           self.count_time = float(str(self.count_time_ledit.text()))
+        except:
+           logging.getLogger("user_level_log").\
                 info("Incorrect count time value.")
         return result and self.count_time
 
@@ -111,7 +111,7 @@ class CreateXRFScanWidget(CreateTaskBase):
     def _create_task(self, sample, shape):
         data_collections = []
 
-	if self.count_time is not None:
+        if self.count_time is not None:
             if not shape:
                 cpos = queue_model_objects.CentredPosition()
                 cpos.snapshot_image = self._shape_history.get_snapshot([])
@@ -128,7 +128,7 @@ class CreateXRFScanWidget(CreateTaskBase):
             xrf_scan = queue_model_objects.XRFScan(sample, path_template, cpos)
             xrf_scan.set_name(path_template.get_prefix())
             xrf_scan.set_number(path_template.run_number)
-	    xrf_scan.count_time = self.count_time
+            xrf_scan.count_time = self.count_time
             data_collections.append(xrf_scan)
 
             self._path_template.run_number += 1

--- a/BlissFramework/Bricks/widgets/create_xrf_spectrum_widget.py
+++ b/BlissFramework/Bricks/widgets/create_xrf_spectrum_widget.py
@@ -15,7 +15,7 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
     def __init__(self, parent = None, name = None, fl = 0):
         CreateTaskBase.__init__(self, parent, name, fl, 'XRF-spectrum')
 
-	self.count_time = None
+        self.count_time = None
 
         # Data attributes
         self.init_models()
@@ -30,12 +30,12 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
                                                data_model = self._path_template,
                                                layout = 'vertical')
 
-	parameters_hor_gbox = qt.QHGroupBox('Parameters', self)
+        parameters_hor_gbox = qt.QHGroupBox('Parameters', self)
 
-	self.count_time_label = qt.QLabel("Count time", parameters_hor_gbox)
+        self.count_time_label = qt.QLabel("Count time", parameters_hor_gbox)
         self.count_time_label.setFixedWidth(83) 
 
-	self.count_time_ledit = qt.QLineEdit("1.0", parameters_hor_gbox,"count_time_ledit")
+        self.count_time_ledit = qt.QLineEdit("1.0", parameters_hor_gbox,"count_time_ledit")
         self.count_time_ledit.setFixedWidth(50)
 
         self.xrfspectrum_mib.bind_value_update('count_time',
@@ -45,8 +45,8 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
         spacer = qt.QWidget(parameters_hor_gbox)
         spacer.setSizePolicy(qt.QSizePolicy.Expanding,qt.QSizePolicy.Fixed)
 
-	v_layout.addWidget(self._data_path_gbox)
-	v_layout.addWidget(parameters_hor_gbox)
+        v_layout.addWidget(self._data_path_gbox)
+        v_layout.addWidget(parameters_hor_gbox)
         v_layout.addStretch()
 
         self.connect(self._data_path_widget.data_path_widget_layout.child('run_number_ledit'),
@@ -98,11 +98,11 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
                 isinstance(shape, shape_history.CanvasGrid)):
                 result = False
 
-	self.count_time = None
-	try:
-	   self.count_time = float(str(self.count_time_ledit.text()))
-	except:
-	   logging.getLogger("user_level_log").\
+        self.count_time = None
+        try:
+           self.count_time = float(str(self.count_time_ledit.text()))
+        except:
+           logging.getLogger("user_level_log").\
                 info("Incorrect count time value.")
         return result and self.count_time
 
@@ -111,7 +111,7 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
     def _create_task(self, sample, shape):
         data_collections = []
 
-	if self.count_time is not None:
+        if self.count_time is not None:
             if not shape:
                 cpos = queue_model_objects.CentredPosition()
                 cpos.snapshot_image = self._shape_history.get_snapshot([])
@@ -128,7 +128,7 @@ class CreateXRFSpectrumWidget(CreateTaskBase):
             xrf_spectrum = queue_model_objects.XRFSpectrum(sample, path_template, cpos)
             xrf_spectrum.set_name(path_template.get_prefix())
             xrf_spectrum.set_number(path_template.run_number)
-	    xrf_spectrum.count_time = self.count_time
+            xrf_spectrum.count_time = self.count_time
             data_collections.append(xrf_spectrum)
 
             self._path_template.run_number += 1

--- a/BlissFramework/Bricks/widgets/dc_tree_widget.py
+++ b/BlissFramework/Bricks/widgets/dc_tree_widget.py
@@ -299,7 +299,7 @@ class DataCollectTree(qt.QWidget):
 
             #Estimate if minidiff is in plate mode
             #This could be done also in a different way
-	    
+
             if self.beamline_setup_hwobj.diffractometer_hwobj.in_plate_mode():
                 self.plate_manipulator_hwobj._doUnload()
             else:

--- a/BlissFramework/Bricks/widgets/scan_plot_widget.py
+++ b/BlissFramework/Bricks/widgets/scan_plot_widget.py
@@ -76,12 +76,12 @@ class ScanPlotWidget(qt.QWidget):
 
     def plotResults(self, pk, fppPeak, fpPeak, ip, fppInfl, fpInfl,
                         rm, chooch_graph_x, chooch_graph_y1, chooch_graph_y2, title):
-	self.graph.clearcurves()	
+        self.graph.clearcurves()
         self.graph.setTitle(title)
         self.graph.newcurve("spline", chooch_graph_x, chooch_graph_y1)
         self.graph.newcurve("fp", chooch_graph_x, chooch_graph_y2)
         self.graph.replot()
-	self.isScanning = False
+        self.isScanning = False
 
     def plotScanCurve(self, scan_data):
         self.graph.clearcurves()

--- a/BlissFramework/Bricks/widgets/widget_utils.py
+++ b/BlissFramework/Bricks/widgets/widget_utils.py
@@ -57,8 +57,8 @@ class DataModelInputBinder(object):
             self._update_widget(field_name, None)
 
     def _update_widget(self, field_name, data_binder):
-	if data_binder == self:
-	    return
+        if data_binder == self:
+            return
         try:
             widget, validator, type_fn = self.bindings[field_name]
         except KeyError:

--- a/BlissFramework/Bricks/widgets/xrf_spectrum_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/xrf_spectrum_parameters_widget.py
@@ -19,8 +19,8 @@ class XRFSpectrumParametersWidget(qt.QWidget):
         self.data_path_widget = DataPathWidget(self)
         self.other_parameters_gbox = qt.QHGroupBox("Other parameters", self)
         self.count_time_label = qt.QLabel("Count time:", self.other_parameters_gbox)
-	self.count_time_ledit = qt.QLineEdit(self.other_parameters_gbox,"count_time_ledit")
-	self.count_time_ledit.setFixedWidth(50)
+        self.count_time_ledit = qt.QLineEdit(self.other_parameters_gbox,"count_time_ledit")
+        self.count_time_ledit.setFixedWidth(50)
 
         spacer = qt.QWidget(self.other_parameters_gbox)
         spacer.setSizePolicy(qt.QSizePolicy.Expanding,qt.QSizePolicy.Fixed)

--- a/BlissFramework/Utils/FileChooser.py
+++ b/BlissFramework/Utils/FileChooser.py
@@ -5,32 +5,32 @@ class FileChooser(QVBox):
     def __init__(self, parent):
         QVBox.__init__(self, parent)
 
-	import os, os.path
-	self.defaultDir = os.getcwd() + '/ '
+        import os, os.path
+        self.defaultDir = os.getcwd() + '/ '
 
-	self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-	self.setSpacing(10)
-	self.setMargin(0)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setSpacing(10)
+        self.setMargin(0)
 
         QLabel('Data file prefix :', self)
-	fileBox = QHBox(self)
-	self.lblDirectory = QLabel(self.defaultDir, fileBox)
-	self.lblDirectory.setAutoResize(True)
-	self.txtFilename = QLineEdit(fileBox)
-	self.cmdBrowse = QPushButton('Browse', fileBox)
-	self.cmdSetAsCurrentFile = QPushButton('Set as data file', self)
+        fileBox = QHBox(self)
+        self.lblDirectory = QLabel(self.defaultDir, fileBox)
+        self.lblDirectory.setAutoResize(True)
+        self.txtFilename = QLineEdit(fileBox)
+        self.cmdBrowse = QPushButton('Browse', fileBox)
+        self.cmdSetAsCurrentFile = QPushButton('Set as data file', self)
 
         QObject.connect(self.cmdBrowse, SIGNAL('clicked()'), self.cmdBrowseClicked)
-	QObject.connect(self.cmdSetAsCurrentFile, SIGNAL('clicked()'), self.cmdSetAsCurrentFileClicked)
+        QObject.connect(self.cmdSetAsCurrentFile, SIGNAL('clicked()'), self.cmdSetAsCurrentFileClicked)
 
 
     def setDefaultDir(self, dir):
-	import os.path
-	self.defaultDir = os.path.normpath(dir) + '/ '
+        import os.path
+        self.defaultDir = os.path.normpath(dir) + '/ '
 
 
     def cmdBrowseClicked(self):
-	directory = QFileDialog.getExistingDirectory(self.defaultDir)  
+        directory = QFileDialog.getExistingDirectory(self.defaultDir)
 
         if not directory.isEmpty():
             directory = str(directory)
@@ -39,22 +39,22 @@ class FileChooser(QVBox):
 
 
     def cmdSetAsCurrentFileClicked(self):
-	import os, os.path
+        import os, os.path
 
-	dir = os.path.normpath(str(self.lblDirectory.text())[:-1])
-	file = str(self.txtFilename.text())
-	
-	if len(file) > 0:
-	    path = os.path.join(dir, file)
-	    existingFiles = ''
-	    root, dirs, files = next(os.walk(dir))	
-	
-	    for f in files+dirs:
+        dir = os.path.normpath(str(self.lblDirectory.text())[:-1])
+        file = str(self.txtFilename.text())
+
+        if len(file) > 0:
+            path = os.path.join(dir, file)
+            existingFiles = ''
+            root, dirs, files = next(os.walk(dir))
+
+            for f in files+dirs:
               if f.startswith(file):
-		existingFiles += '%s\n' % f
-		 
-	    if len(existingFiles) > 0:
-	      if QMessageBox.question(None, 'Filename conflict', 'Are you sure you want to delete these files :\n%s' % existingFiles, QMessageBox.Yes, QMessageBox.No, QMessageBox.Cancel) != QMessageBox.Yes:
-		return
+                existingFiles += '%s\n' % f
 
-	    self.emit(PYSIGNAL('dataFileChanged'), (path, ))
+            if len(existingFiles) > 0:
+              if QMessageBox.question(None, 'Filename conflict', 'Are you sure you want to delete these files :\n%s' % existingFiles, QMessageBox.Yes, QMessageBox.No, QMessageBox.Cancel) != QMessageBox.Yes:
+                return
+
+            self.emit(PYSIGNAL('dataFileChanged'), (path, ))

--- a/BlissFramework/startGUI.py
+++ b/BlissFramework/startGUI.py
@@ -44,7 +44,7 @@ def run(GUIConfigFile=None):
     parser.add_option('', '--hardwareRepository', action = 'store', type = 'string', help = 'Hardware Repository Server host:port (default to %s) (you can also use HARDWARE_REPOSITORY_SERVER the environment variable)' % defaultHwrServer, metavar = 'HOST:PORT', dest = 'hardwareRepositoryServer', default = '')                   
     parser.add_option('', '--hardwareObjectsDirs', action = 'store', type = 'string', help = 'Additional directories for Hardware Objects search path (you can also use the CUSTOM_HARDWARE_OBJECTS_PATH environment variable)', dest = 'hardwareObjectsDirs', metavar = 'dir1'+os.path.pathsep+'dir2...dirN', default = '')
     parser.add_option('-d', '', action='store_true', dest="designMode", default=False, help="start GUI in Design mode")
-    parser.add_option('-m', '', action='store_true', dest="showMaximized", default=False, help="maximize main window")	
+    parser.add_option('-m', '', action='store_true', dest="showMaximized", default=False, help="maximize main window")
     parser.add_option('', '--no-border', action='store_true', dest='noBorder', default=False, help="does not show borders on main window")
     parser.add_option('-w', '--web-server-port', action='store', type="int", dest='webServerPort', default=0, help="port number for the remote interpreter web application server")
     #parser.add_option('', '--widgetcount', action='store_true', dest='widgetCount', default=False, help="prints debug message at the end about number of widgets left undestroyed")


### PR DESCRIPTION
I kept coming across files where the indentation had an inconsistent mix of tabs and spaces. The present pull request replaces all tabs globally with 8*' ' (eight spaces).

NB The changes are eyeballed but NOT tested (I do not have a test set-up for master).

Looks like I combined two commits into this one (sorry). The other one is:

#Changed cases where a get function returned internal lists or dicts to return a copy.

NB1 This is not tested - I do not have a test set-up for master

NB2 Two clear cases were left alone as being too complicated for em to deal with:
BeamInfo.get_beam_info and predefinedPositionsNamesList

Also changed some out-of-place tab indentations to spaces and some CR-LF to CR