### PR TITLE
[master] 2017.11.10. Qt4_TreeBrick bugfix

### DIFF
--- a/BlissFramework/Bricks/Qt4_TreeBrick.py
+++ b/BlissFramework/Bricks/Qt4_TreeBrick.py
@@ -382,9 +382,9 @@ class Qt4_TreeBrick(BlissWidget):
                              'open_dialog',
                              self.open_xmlrpc_dialog)
         elif property_name == 'hwobj_state_machine':
-              self.state_machine_hwobj = self.getHardwareObject(new_value)
+              self.state_machine_hwobj = self.getHardwareObject(new_value, optional=True)
         elif property_name == 'redis_client':
-              self.redis_client_hwobj = self.getHardwareObject(new_value)
+              self.redis_client_hwobj = self.getHardwareObject(new_value, optional=True)
         elif property_name == 'scOneName':
               self.sample_changer_widget.filter_cbox.setItemText(1, new_value)
         elif property_name == 'scTwoName':


### PR DESCRIPTION
* Add redis and state machine hwobj as optional. It will not paint the widget red if the hardware objects is not initialized

A yes, forgot to write in previous PR:
* Widget is painted red and a log message is displayed if the loading of hwobj fails. It is possible to avoid this by adding option: optional=True when calling getHardwareObject