### PR TITLE
[master] Periodic table bugfix

### DIFF
--- a/BlissFramework/Bricks/widgets/Qt4_periodic_table_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_periodic_table_widget.py
@@ -140,7 +140,7 @@ class PeriodicTableWidget(QWidget):
 if pymca_imported: 
     class CustomPeriodicTable(QPeriodicTable.QPeriodicTable):
 
-        elementClicked = pyqtSignal(str)
+        #elementClicked = pyqtSignal(str)
         edgeSelectedSignal = pyqtSignal(str, str)
 
         def __init__(self, *args):


### PR DESCRIPTION
Fixed bug when it was unable to select element from the table.
elementClicked signal is originaly in PyMca and defining it here made a confusion.