### PR TITLE
[master] Bugfix for latest Gphl changes

### DIFF
--- a/BlissFramework/Bricks/widgets/Qt4_gphl_acquisition_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_gphl_acquisition_widget.py
@@ -165,6 +165,10 @@ class GphlDiffractcalWidget(GphlSetupWidget):
         wf_hwobj = HardwareRepository.HardwareRepository().getHardwareObject(
             'gphl-workflow'
         )
+
+        if not wf_hwobj:
+            return
+
         xx = next(wf_hwobj.getObjects("test_crystals"))
         for test_crystal in xx.getObjects("test_crystal"):
             dd = test_crystal.getProperties()


### PR DESCRIPTION
* Do not constract widget if the hwobj is not loaded.

Please consider other way of loading hwobj, because now `gphl-workflow` is hard coded and loading of hwobj fails:

```
File "/home/karpics/mxcube/mxcubeMaster/HardwareRepository/HardwareObjects/GphlWorkflow.py", line 17, in <module>
    import f90nml
  File "/usr/lib/python2.7/dist-packages/gevent/builtins.py", line 93, in __import__
    result = _import(*args, **kwargs)
ImportError: No module named f90nml
```