### PR TITLE
Sample changer bricks improvements

### DIFF
--- a/BlissFramework/Bricks/Qt4_CatsMaintBrick.py
+++ b/BlissFramework/Bricks/Qt4_CatsMaintBrick.py
@@ -150,13 +150,13 @@ class Qt4_CatsMaintBrick(BlissWidget):
         self.update_buttons()
 
     def update_state(self, state):
-        logging.getLogger("HWR").debug("CATS update state : " + str(state))
+        logging.getLogger().debug("CATS update state : " + str(state))
         if state != self.state:
             self.state  = state
             self.update_buttons()
 
     def update_status(self, status):
-        logging.getLogger("HWR").debug("CATS update status : " + str(status))
+        logging.getLogger().debug("CATS update status : " + str(status))
         if status != self.status:
             self.status  = status
 
@@ -171,7 +171,7 @@ class Qt4_CatsMaintBrick(BlissWidget):
         self.update_buttons()
 
     def update_powered(self, value):
-        logging.getLogger("HWR").debug("CATS update powered : " + str(value))
+        logging.getLogger().debug("CATS update powered : " + str(value))
         self.powered = value
         if value:
             light_green = str(Qt4_widget_colors.LIGHT_GREEN.name())
@@ -182,7 +182,7 @@ class Qt4_CatsMaintBrick(BlissWidget):
         self.update_buttons()
 
     def update_message(self, value):
-        logging.getLogger("HWR").debug("CATS update message : " + str(value))
+        logging.getLogger().debug("CATS update message : " + str(value))
         self.widget.lblMessage.setText(str(value))
 
     def update_barcode(self, value):
@@ -190,7 +190,7 @@ class Qt4_CatsMaintBrick(BlissWidget):
             barcode = value
         else: 
             barcode = "----"
-        logging.getLogger("HWR").debug("CATS update barcode : " + str(barcode))
+        logging.getLogger().debug("CATS update barcode : " + str(barcode))
         self.widget.lblMessage.setText(str(value))
 
     def update_path_running(self, value):

--- a/BlissFramework/Bricks/Qt4_CatsSimpleBrick.py
+++ b/BlissFramework/Bricks/Qt4_CatsSimpleBrick.py
@@ -37,17 +37,20 @@ from QtImport import *
 
 from Qt4_SampleChangerBrick3 import Qt4_SampleChangerBrick3, BasketView, VialView
 from Qt4_sample_changer_helper import *
+from BlissFramework.Qt4_BaseComponents import BlissWidget
 
 __category__ = "Sample changer"
 
-class CatsStatusView(QGroupBox):
+class CatsStatusView(QGroupBox, BlissWidget):
 
-    def __init__(self, parent):
-        QGroupBox.__init__(self, "Sample Changer State", parent)
-
+    def __init__(self, parent, brick):
+        
+        QGroupBox.__init__(self, "State", parent)
+        BlissWidget.__init__(self, parent)
         # Graphic elements ----------------------------------------------------
         #self.contents_widget = QGroupBox("Sample Changer State", self)
 
+        self._parent = brick
         self.status_label = QLabel("")
         self.status_label.setAlignment(Qt.AlignCenter)
 
@@ -59,13 +62,13 @@ class CatsStatusView(QGroupBox):
         _layout.setContentsMargins(6,6,6,10)
 
     def setStatusMsg(self, status):
-        logging.getLogger("HWR").debug(">>>>> CATS Brick Setting status msg to " + str(status)) 
         self.status_label.setToolTip(status)
         status = status.strip()
         self.setToolTip(status)
 
     def setState(self, state):
-        logging.getLogger("HWR").debug(">>>>> CATS Brick Setting state to " + str(state)) 
+       
+        logging.getLogger("HWR").debug("SC StatusView. State changed %s" % str(state))
         color = SC_STATE_COLOR.get(state, None)
 
         if color is None:
@@ -75,7 +78,9 @@ class CatsStatusView(QGroupBox):
 
         enabled = SC_STATE_GENERAL.get(state, False)
         self.status_label.setEnabled(enabled)
-        self.status_label.setText(SampleChangerState.tostring(state))
+        state_str = SampleChangerState.tostring(state)
+        self.status_label.setText(state_str)
+        self._parent.set_status_info("sc", state_str)
        
     def setIcons(self, *args):
         pass
@@ -143,7 +148,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
 
 
     def build_status_view(self, container):
-        return CatsStatusView(container)
+        return CatsStatusView(container, self)
 
     def build_operations_widget(self):
         self.buttons_layout = QHBoxLayout()
@@ -188,9 +193,10 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
 
         if self.has_basket_HT:
              vials = [[VialView.VIAL_BARCODE]] *10 
-             self.baskets[-1].setMatrices(vials)
+             self.baskets[-1].set_matrices(vials)
 
     def sc_state_changed(self, state, previous_state=None):
+        logging.getLogger("HWR").debug("SC State changed %s" % str(state))
         Qt4_SampleChangerBrick3.sc_state_changed(self, state, previous_state)
 
         self.state = state
@@ -206,11 +212,15 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
 
     def _updateButtons(self):
         running = self._pathRunning and True or False
+
         if self.state in [SampleChangerState.Ready, SampleChangerState.StandBy]:
             ready = not running
         else:
             ready = False
+
         poweredOn = self._poweredOn and True or False # handles init state None as False
+
+        logging.getLogger("HWR").debug("updating buttons %s / %s / %s" % (running, poweredOn, self.state))
 
         if not poweredOn:
             self.load_button.setEnabled(False)
@@ -218,6 +228,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
             self.abort_button.setEnabled(False)
             abort_color = Qt4_widget_colors.LIGHT_GRAY
         elif ready:
+            logging.getLogger("HWR").info("Qt4_CatsSimpleBrick update buttons (ready)")
             self.load_button.setEnabled(True)
             if self.sample_changer_hwobj.hasLoadedSample():
                 self.unload_button.setEnabled(True)
@@ -226,23 +237,20 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
             self.abort_button.setEnabled(False)
             abort_color = Qt4_widget_colors.LIGHT_GRAY
         else:
+            logging.getLogger("HWR").info("Qt4_CatsSimpleBrick update buttons (other)")
             self.load_button.setEnabled(False)
             self.unload_button.setEnabled(False)
             self.abort_button.setEnabled(True)
             abort_color = Qt4_widget_colors.LIGHT_RED
 
-        Qt4_widget_colors.set_widget_color(self.abort_button, abort_color)
+        self.abort_button.setStyleSheet("background-color: %s;" % abort_color.name())
+
+        #Qt4_widget_colors.set_widget_color(self.abort_button, abort_color)
 
     def load_selected_sample(self):
 
         basket, vial = self.user_selected_sample
-        logging.getLogger("GUI").info("Loading sample basket: %s / %s" % (basket, vial))
-
-        if self.sample_changer_hwobj.read_diff_phase().upper() != "TRANSFER":
-             _res = QMessageBox.warning(self, "Loading aborted", 
-                 "Diffractometer is not in TRANSFER phase.  Loading sample aborted", 
-                 QMessageBox.Ok)
-             return
+        logging.getLogger("GUI").info("Loading sample: %s / %s" % (basket, vial))
 
         if basket is not None and vial is not None:
             if basket != 100:
@@ -253,7 +261,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
                 logging.getLogger("GUI").info("Is an HT sample: idx=%s (not implemented yet)" % (vial))
 
     def unload_selected_sample(self):
-        logging.getLogger("GUI").info("Unloading sample basket") 
+        logging.getLogger("GUI").info("Unloading sample") 
         self.sample_changer_hwobj.unload()
 
     def abort_mounting(self):

--- a/BlissFramework/Bricks/Qt4_CatsSimpleBrick.py
+++ b/BlissFramework/Bricks/Qt4_CatsSimpleBrick.py
@@ -68,7 +68,7 @@ class CatsStatusView(QGroupBox, BlissWidget):
 
     def setState(self, state):
        
-        logging.getLogger("HWR").debug("SC StatusView. State changed %s" % str(state))
+        logging.getLogger().debug("SC StatusView. State changed %s" % str(state))
         color = SC_STATE_COLOR.get(state, None)
 
         if color is None:
@@ -196,7 +196,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
              self.baskets[-1].set_matrices(vials)
 
     def sc_state_changed(self, state, previous_state=None):
-        logging.getLogger("HWR").debug("SC State changed %s" % str(state))
+        logging.getLogger().debug("SC State changed %s" % str(state))
         Qt4_SampleChangerBrick3.sc_state_changed(self, state, previous_state)
 
         self.state = state
@@ -220,7 +220,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
 
         poweredOn = self._poweredOn and True or False # handles init state None as False
 
-        logging.getLogger("HWR").debug("updating buttons %s / %s / %s" % (running, poweredOn, self.state))
+        logging.getLogger().debug("updating buttons %s / %s / %s" % (running, poweredOn, self.state))
 
         if not poweredOn:
             self.load_button.setEnabled(False)
@@ -228,7 +228,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
             self.abort_button.setEnabled(False)
             abort_color = Qt4_widget_colors.LIGHT_GRAY
         elif ready:
-            logging.getLogger("HWR").info("Qt4_CatsSimpleBrick update buttons (ready)")
+            logging.getLogger().info("Qt4_CatsSimpleBrick update buttons (ready)")
             self.load_button.setEnabled(True)
             if self.sample_changer_hwobj.hasLoadedSample():
                 self.unload_button.setEnabled(True)
@@ -237,7 +237,7 @@ class Qt4_CatsSimpleBrick(Qt4_SampleChangerBrick3):
             self.abort_button.setEnabled(False)
             abort_color = Qt4_widget_colors.LIGHT_GRAY
         else:
-            logging.getLogger("HWR").info("Qt4_CatsSimpleBrick update buttons (other)")
+            logging.getLogger().info("Qt4_CatsSimpleBrick update buttons (other)")
             self.load_button.setEnabled(False)
             self.unload_button.setEnabled(False)
             self.abort_button.setEnabled(True)

--- a/BlissFramework/Bricks/Qt4_SampleChangerBrick3.py
+++ b/BlissFramework/Bricks/Qt4_SampleChangerBrick3.py
@@ -84,7 +84,7 @@ class VialView(QWidget):
         return self.vial_code
 
     def set_selected(self, state):
-        logging.getLogger("HWR").debug("VialView %s, selected %s" % (self.vial_index, state))
+        logging.getLogger().debug("VialView %s, selected %s" % (self.vial_index, state))
 
         if state is True:
             Qt4_widget_colors.set_widget_color(self, \
@@ -96,12 +96,12 @@ class VialView(QWidget):
 
     def mousePressEvent(self, event):
         """Mouse single clicked event"""
-        logging.getLogger("HWR").debug("mouse pressed on vial view")
+        logging.getLogger().debug("mouse pressed on vial view")
         QWidget.mousePressEvent(self,event)
         
     def mouseReleaseEvent(self, event):
         """Mouse single clicked event"""
-        logging.getLogger("HWR").debug("mouse released on vial view")
+        logging.getLogger().debug("mouse released on vial view")
         self.singleClickSignal.emit(self.vial_index)
         QWidget.mouseReleaseEvent(self,event)
 
@@ -120,7 +120,7 @@ class VialNumberView(QLabel):
 
     def mousePressEvent(self, event):
         """Mouse single clicked event"""
-        logging.getLogger("HWR").debug("mouse pressed on vial number view")
+        logging.getLogger().debug("mouse pressed on vial number view")
         QWidget.mousePressEvent(self,event)
         
     def mouseReleaseEvent(self, event):
@@ -176,12 +176,12 @@ class SampleBox(QWidget):
             Qt4_widget_colors.LINE_EDIT_CHANGED)
     
     def mousePressEvent(self, event):
-        logging.getLogger("HWR").debug("mouse press on sample %s" % self.vial_index) 
+        logging.getLogger().debug("mouse press on sample %s" % self.vial_index) 
         QWidget.mousePressEvent(self,event)
 
     def mouseReleaseEvent(self, event):
         """Mouse single clicked event"""
-        logging.getLogger("HWR").debug("mouse release on sample %s" % self.vial_index) 
+        logging.getLogger().debug("mouse release on sample %s" % self.vial_index) 
         self.singleClickSignal.emit(self.vial_index)
         QWidget.mouseReleaseEvent(self,event)
         
@@ -1042,9 +1042,9 @@ class Qt4_SampleChangerBrick3(BlissWidget):
                 #self.current_sample_view.hideHolderLength(self.sample_changer_hwobj.isMicrodiff())
                 #self.status.hideOperationalControl(self.sample_changer_hwobj.isMicrodiff())
                 self.sc_status_changed(self.sample_changer_hwobj.getStatus())
-                logging.getLogger("HWR").debug("Updating sc state (first)")
+                logging.getLogger().debug("Updating sc state (first)")
                 self.sc_state_changed(self.sample_changer_hwobj.getState())
-                logging.getLogger("HWR").debug("   / done" )
+                logging.getLogger().debug("   / done" )
                 self.infoChanged()
                 self.selectionChanged()
                 #self.sample_changer_hwobjInUse(self.sampleChanger.sampleChangerInUse())
@@ -1126,7 +1126,7 @@ class Qt4_SampleChangerBrick3(BlissWidget):
         self.sample_changer_hwobj.changeMode(SampleChangerMode.Normal, wait=False)
 
     def loadedSampleChanged(self, sample):
-        logging.getLogger("HWR").info("Brick received new sample loaded %s" % sample)
+        logging.getLogger().info("Brick received new sample loaded %s" % sample)
         if sample is None:
             # get current location in SC
             sample = self.sample_changer_hwobj.getSelectedSample()
@@ -1141,7 +1141,7 @@ class Qt4_SampleChangerBrick3(BlissWidget):
         else:
             barcode = sample.getID()
             location = sample.getCoords()
-        logging.getLogger("HWR").info("     sample location is %s" % str(location))
+        logging.getLogger().info("     sample location is %s" % str(location))
         
         self.current_sample_view.setLoadedMatrixCode(barcode)
         self.current_sample_view.setLoadedLocation(location)
@@ -1190,11 +1190,11 @@ class Qt4_SampleChangerBrick3(BlissWidget):
         self.sample_changer_hwobjStateChanged(state)
 
     def sc_status_changed(self, status):
-        logging.getLogger("HWR").debug("Status changed %s" % status) 
+        logging.getLogger().debug("Status changed %s" % status) 
         self.status.setStatusMsg(status)
 
     def sc_state_changed(self, state, previous_state=None):
-        logging.getLogger("HWR").debug("State changed %s" % state) 
+        logging.getLogger().debug("State changed %s" % state) 
         self.status.setState(state)
         self.current_basket_view.setState(state)
         self.current_sample_view.setState(state)
@@ -1233,7 +1233,7 @@ class Qt4_SampleChangerBrick3(BlissWidget):
         self.sample_changer_hwobj.select(address, wait=False)
 
     def user_select_this_sample(self, basket_index, vial_index):
-        logging.getLogger("HWR").debug("user select sample %s %s" % (basket_index, vial_index))
+        logging.getLogger().debug("user select sample %s %s" % (basket_index, vial_index))
         if self.single_click_selection:
             self.user_selected_sample = (basket_index, vial_index)
             self.reset_selection()


### PR DESCRIPTION
Qt4_CatsSimpleBrick
 -- allow CatsStatusView to inherit from BlissWidget in addition to QGroupBox
 -- improving log messages
Qt4_SampleChangerBrick3
 -- More flexible layout of samples. Redefining mouse vial click events. Not limiting number of samples per basket to 10.



