### PR TITLE
Soleil configuration updates

### DIFF
--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/beamline-setup.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/beamline-setup.xml
@@ -1,0 +1,100 @@
+<object class="BeamlineSetup">
+    <!-- Objects directly associatd with hardware -->
+    <object href="/diffractometer/diffractometer" role="diffractometer"/>
+    <object href="/diffractometer/omega" role="omega_axis"/>
+    <object href="/diffractometer/kappa" role="kappa_axis"/>
+    <object href="/diffractometer/phi" role="kappa_phi_axis"/>
+    <object href="/singleton_objects/cats" role="sample_changer"/>    
+    <object href="/singleton_motors/resolution" role="resolution"/>
+    <object href="/singleton_motors/photon_energy" role="energy"/>
+    <object href="/singleton_motors/transmission" role="transmission"/>
+
+    <!-- Software (abstract) concepts -->
+    <object href="/singleton_objects/beaminfo_exporter" role="beam_info"/>
+    <object href="/singleton_objects/Qt4_graphics-manager" role="shape_history"/>
+    <object href="/singleton_objects/session" role="session"/>
+    <object href="/singleton_objects/dbconnection" role="lims_client"/>
+    <object href="/singleton_objects/data-analysis" role="data_analysis"/>
+    
+    <!-- Procedures and routines -->
+    <object href="/mockups/energyscan-mockup" role="energyscan"/>
+    <object href="/experimental_methods/diffraction_methods" role="collect"/>
+    <object href="/singleton_objects/parallel-processing" role="parallel_processing"/>
+    <object href="/mockups/xrf-spectrum-mockup" role="xrf_spectrum"/>
+    <object href="/mockups/detector-mockup" role="detector"/>
+
+    <!-- advanced methods are defined as a list with method names.
+        Each name is then converted to class name.
+        For example Mesh scan -> MeshScan, Xray centring -> XrayCentring
+        and used as a queue_entry. If queue entry is missing
+        then queue skip exception will be raised.
+    -->
+    <advancedMethods>["MeshScan", "XrayCentering", "LineScan"]</advancedMethods>
+
+    <!-- Is it possible to change the beam wavelentgh.
+        Should perhaps be associated with the diffractometer -->
+    <tunable_wavelength>True</tunable_wavelength>
+
+    <!-- Disables or enables the number of passes input box, used
+    for acquisitions.-->
+    <disable_num_passes>True</disable_num_passes>
+
+    <!-- Default values for an acquisition -->
+    <default_acquisition_values>
+        <exposure_time>0.025</exposure_time>
+        <start_angle>0.0</start_angle>
+        <range>0.1</range>
+        <number_of_passes>1</number_of_passes>
+        <start_image_number>1</start_image_number>
+        <run_number>1</run_number>
+        <overlap>0</overlap>
+        <number_of_images>1800</number_of_images>
+        <detector_mode>1</detector_mode>
+    </default_acquisition_values>
+
+    <default_helical_values>
+        <exposure_time>0.025</exposure_time>
+        <start_angle>0.0</start_angle>
+        <range>0.1</range>
+        <number_of_passes>1</number_of_passes>
+        <start_image_number>1</start_image_number>
+        <run_number>1</run_number>
+        <overlap>0</overlap>
+        <number_of_images>1800</number_of_images>
+        <detector_mode>1</detector_mode>
+    </default_helical_values>
+
+    <!-- Default values for a characterization -->
+    <default_characterisation_values>
+        <exposure_time>0.025</exposure_time>
+        <start_angle>0.0</start_angle>
+        <range>0.1</range>
+        <number_of_passes>1</number_of_passes>
+        <start_image_number>1</start_image_number>
+        <run_number>1</run_number>
+        <overlap>-89</overlap>
+        <number_of_images>1</number_of_images>
+        <detector_mode>1</detector_mode>
+        <number_of_wedges></number_of_wedges>
+        <wedge_size>10</wedge_size>
+    </default_characterisation_values>
+
+    <default_advanced_values>
+        <exposure_time>0.025</exposure_time>
+        <start_angle>0.0</start_angle>
+        <range>0.5</range>
+        <number_of_passes>1</number_of_passes>
+        <start_image_number>1</start_image_number>
+        <run_number>1</run_number>
+        <overlap>0</overlap>
+        <number_of_images>100</number_of_images>
+        <detector_mode>1</detector_mode>
+    </default_advanced_values>
+
+    <acquisition_limit_values>
+        <kappa>-9, 240</kappa>
+        <osc_range>-1000,10000</osc_range>
+        <exposure_time>0.00134,6000</exposure_time>
+        <number_of_images>1,99999</number_of_images>
+    </acquisition_limit_values>
+ </object>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmentx.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmentx.xml
@@ -1,1 +1,15 @@
-exporter/alignmentx.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>AlignmentX</motor_name>
+    <username>AlignmentX</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="AlignmentXPosition">AlignmentXPosition</channel>
+    <channel type="exporter" name="AlignmentXState">AlignmentXState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getAlignmentXDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmenty.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmenty.xml
@@ -1,1 +1,15 @@
-exporter/alignmenty.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>AlignmentY</motor_name>
+    <username>AlignmentY</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="AlignmentYPosition">AlignmentYPosition</channel>
+    <channel type="exporter" name="AlignmentYState">AlignmentYState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getAlignmentYDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmentz.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/alignmentz.xml
@@ -1,1 +1,15 @@
-exporter/alignmentz.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>AlignmentZ</motor_name>
+    <username>AlignmentZ</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="AlignmentZPosition">AlignmentZPosition</channel>
+    <channel type="exporter" name="AlignmentZState">AlignmentZState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getAlignmentZDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture.xml
@@ -1,1 +1,7 @@
-exporter/aperture.xml
+<device class="EMBLAperture">
+   <exporter_address>172.19.10.119:9001</exporter_address>
+   <channel type="exporter" name="CurrentApertureDiameterIndex">CurrentApertureDiameterIndex</channel>
+   <channel type="exporter" name="ApertureDiameters">ApertureDiameters</channel>
+   <channel type="exporter" name="AperturePosition">AperturePosition</channel>
+   <channel type="exporter" name="State">State</channel>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture_diameter.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture_diameter.xml
@@ -1,1 +1,8 @@
-exporter/aperture_diameter.xml
+<device class="NamedState">
+    <username>Diameter</username>
+    <exporter_address>172.19.10.119:9001</exporter_address>    
+    <channel type="exporter" name="state">CurrentApertureDiameterIndex</channel>
+    <channel type="exporter" name="hardware_state">State</channel>
+    <channel type="exporter" name="statelist">ApertureDiameters</channel>
+    <commandtype>index</commandtype>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture_position.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperture_position.xml
@@ -1,1 +1,17 @@
-exporter/aperture_position.xml
+<device class="NamedState">
+    <username>Position</username>
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <channel type="exporter" name="state">AperturePosition</channel>
+    <channel type="exporter" name="hardware_state">State</channel>
+    <states>
+       <state>
+          <name>PARK</name>
+       </state>
+       <state>
+          <name>BEAM</name>
+       </state>
+       <state>
+          <name>OFF</name>
+       </state>
+    </states>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperturehorizontal.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperturehorizontal.xml
@@ -1,1 +1,15 @@
-exporter/aperturehorizontal.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>ApertureHorizontal</motor_name>
+    <username>ApertureHorizontal</username>
+    <direction>1</direction>
+    <GUIstep>0.025</GUIstep>
+    <channel type="exporter" name="ApertureHorizontalPosition">ApertureHorizontalPosition</channel>
+    <channel type="exporter" name="ApertureHorizontalState">ApertureHorizontalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getApertureHorizontalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperturevertical.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/aperturevertical.xml
@@ -1,1 +1,15 @@
-exporter/aperturevertical.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>ApertureVertical</motor_name>
+    <username>ApertureVertical</username>
+    <direction>1</direction>
+    <GUIstep>0.025</GUIstep>
+    <channel type="exporter" name="ApertureVerticalPosition">ApertureVerticalPosition</channel>
+    <channel type="exporter" name="ApertureVerticalState">ApertureVerticalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getApertureVerticalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/backlight.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/backlight.xml
@@ -1,1 +1,7 @@
-exporter/backlight.xml
+<device class="MicrodiffLight">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>BackLight</motor_name>
+    <channel type="exporter" name="chanLightValue">BackLightLevel</channel>
+    <channel type="exporter" name="chanLightIsOn">BackLightIsOn</channel>
+    <limits>[0, 100]</limits>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopx.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopx.xml
@@ -1,1 +1,15 @@
-exporter/beamstopx.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>BeamstopX</motor_name>
+    <username>BeamstopX</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="BeamstopXPosition">BeamstopXPosition</channel>
+    <channel type="exporter" name="BeamstopXState">BeamstopXState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getBeamstopXDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopy.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopy.xml
@@ -1,1 +1,15 @@
-exporter/beamstopy.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>BeamstopY</motor_name>
+    <username>BeamstopY</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="BeamstopYPosition">BeamstopYPosition</channel>
+    <channel type="exporter" name="BeamstopYState">BeamstopYState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getBeamstopYDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopz.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/beamstopz.xml
@@ -1,1 +1,15 @@
-exporter/beamstopz.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>BeamstopZ</motor_name>
+    <username>BeamstopZ</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="BeamstopZPosition">BeamstopZPosition</channel>
+    <channel type="exporter" name="BeamstopZState">BeamstopZState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getBeamstopZDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/capillaryhorizontal.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/capillaryhorizontal.xml
@@ -1,1 +1,15 @@
-exporter/capillaryhorizontal.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CapillaryHorizontal</motor_name>
+    <username>CapillaryHorizontal</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CapillaryHorizontalPosition">CapillaryHorizontalPosition</channel>
+    <channel type="exporter" name="CapillaryHorizontalState">CapillaryHorizontalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCapillaryHorizontalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/capillaryvertical.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/capillaryvertical.xml
@@ -1,1 +1,15 @@
-exporter/capillaryvertical.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CapillaryVertical</motor_name>
+    <username>CapillaryVertical</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CapillaryVerticalPosition">CapillaryVerticalPosition</channel>
+    <channel type="exporter" name="CapillaryVerticalState">CapillaryVerticalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCapillaryVerticalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringtablefocus.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringtablefocus.xml
@@ -1,1 +1,15 @@
-exporter/centringtablefocus.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CentringTableFocus</motor_name>
+    <username>CentringTableFocus</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CentringTableFocusPosition">CentringTableFocusPosition</channel>
+    <channel type="exporter" name="CentringTableFocusState">CentringTableFocusState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCentringTableFocusDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringtablevertical.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringtablevertical.xml
@@ -1,1 +1,15 @@
-exporter/centringtablevertical.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CentringTableVertical</motor_name>
+    <username>CentringTableVertical</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CentringTableVerticalPosition">CentringTableVerticalPosition</channel>
+    <channel type="exporter" name="CentringTableVerticalState">CentringTableVerticalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCentringTableVerticalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringx.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringx.xml
@@ -1,1 +1,15 @@
-exporter/centringx.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CentringX</motor_name>
+    <username>CentringX</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CentringXPosition">CentringXPosition</channel>
+    <channel type="exporter" name="CentringXState">CentringXState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCentringXDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringy.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/centringy.xml
@@ -1,1 +1,15 @@
-exporter/centringy.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>CentringY</motor_name>
+    <username>CentringY</username>
+    <direction>1</direction>
+    <GUIstep>0.05</GUIstep>
+    <channel type="exporter" name="CentringYPosition">CentringYPosition</channel>
+    <channel type="exporter" name="CentringYState">CentringYState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getCentringYDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/diffractometer.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/diffractometer.xml
@@ -1,1 +1,42 @@
-exporter/diffractometer.xml
+<object class="PX2Diffractometer">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <channel type="exporter" name="CoaxCamScaleX">CoaxCamScaleX</channel>
+    <channel type="exporter" name="CoaxCamScaleY">CoaxCamScaleY</channel>
+    <channel type="exporter" name="HeadType">HeadType</channel>
+    <channel type="exporter" name="CurrentPhase">CurrentPhase</channel>
+    <channel type="exporter" name="FastShutterIsOpen">FastShutterIsOpen</channel>
+    <channel type="exporter" name="State">State</channel>
+    <channel type="exporter" name="Status">Status</channel>
+
+    <channel type="exporter" name="ScintillatorPosition">ScintillatorPosition</channel>
+    <channel type="exporter" name="CapillaryPosition">CapillaryPosition</channel>
+    <channel type="exporter" name="TransferMode">TransferMode</channel>
+    <channel type="exporter" name="SampleIsLoaded">SampleIsLoaded</channel>
+    <command type="exporter" name="startSetPhase">startSetPhase</command>
+    <command type="exporter" name="startAutoFocus">startAutoFocus</command>
+    <command type="exporter" name="saveCentringPositions">saveCentringPositions</command>
+    <command type="exporter" name="getOmegaMotorDynamicScanLimits">getOmegaMotorDynamicScanLimits</command>
+
+    <object href="/diffractometer/omega" role="phi"/>
+    <object href="/diffractometer/alignmentz" role="phiz"/>
+    <object href="/diffractometer/alignmenty" role="phiy"/>
+    <object href="/diffractometer/predefined-zoom" role="zoom"/>
+    <object href="/diffractometer/centringtablefocus" role="focus"/>
+    <object href="/diffractometer/centringx" role="sampx"/>
+    <object href="/diffractometer/centringy" role="sampy"/>
+    <object href="/diffractometer/kappa" role="kappa"/>
+    <object href="/diffractometer/phi" role="kappa_phi"/>
+    <object href="/singleton_objects/camera" role="camera"/>
+    <object href="/singleton_objects/beaminfo" role="beam_info"/>
+    <object href="/singleton_objects/centring-math" role="centring"/>
+    <object href="/singleton_objects/minikappa-correction" role="minikappa_correction"/>
+    <object href="/singleton_objects/camera" role="camera"/>
+    <object href="/singleton_objects/cats" role="samplechanger"/>
+    
+    <use_sample_changer>True</use_sample_changer> 
+    <zoom_centre>{"x": 680,"y": 512}</zoom_centre>
+
+    <omega_reference>{"motor_name": "phiz", "position": -0.121, "camera_axis":"y","direction": -1}</omega_reference>
+    <grid_direction>{"fast": (1, 0), "slow": (0, -1), "omega_ref" : 0.0}</grid_direction>
+    <reversing_rotation>True</reversing_rotation>
+</object>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/exporter/diffractometer.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/exporter/diffractometer.xml
@@ -19,15 +19,15 @@
     <command type="exporter" name="saveCentringPositions">saveCentringPositions</command>
     <command type="exporter" name="getOmegaMotorDynamicScanLimits">getOmegaMotorDynamicScanLimits</command>
 
-    <object href="/goniometer/exporter/omega" role="phi"/>
-    <object href="/goniometer/exporter/alignmentz" role="phiz"/>
-    <object href="/goniometer/exporter/alignmenty" role="phiy"/>
-    <object href="/goniometer/exporter/predefined-zoom" role="zoom"/>
-    <object href="/goniometer/exporter/centringtablefocus" role="focus"/>
-    <object href="/goniometer/exporter/centringx" role="sampx"/>
-    <object href="/goniometer/exporter/centringy" role="sampy"/>
-    <object href="/goniometer/exporter/kappa" role="kappa"/>
-    <object href="/goniometer/exporter/phi" role="kappa_phi"/>
+    <object href="/diffractometer/exporter/omega" role="phi"/>
+    <object href="/diffractometer/exporter/alignmentz" role="phiz"/>
+    <object href="/diffractometer/exporter/alignmenty" role="phiy"/>
+    <object href="/diffractometer/exporter/predefined-zoom" role="zoom"/>
+    <object href="/diffractometer/exporter/centringtablefocus" role="focus"/>
+    <object href="/diffractometer/exporter/centringx" role="sampx"/>
+    <object href="/diffractometer/exporter/centringy" role="sampy"/>
+    <object href="/diffractometer/exporter/kappa" role="kappa"/>
+    <object href="/diffractometer/exporter/phi" role="kappa_phi"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/beaminfo" role="beam_info"/>
     <object href="/singleton_objects/centring-math" role="centring"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/fastshutter.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/fastshutter.xml
@@ -1,1 +1,5 @@
-exporter/fastshutter.xml
+<device class="MDFastShutter">
+  <exporter_address>172.19.10.119:9001</exporter_address>
+  <channel type="exporter" name="chanShutterState">FastShutterIsOpen</channel>
+  <channel type="exporter" name="chanCurrentPhase">CurrentPhase</channel>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/frontlight.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/frontlight.xml
@@ -1,1 +1,7 @@
-exporter/frontlight.xml
+<device class="MicrodiffLight">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>FrontLight</motor_name>
+    <channel type="exporter" name="chanLightValue">FrontLightLevel</channel>
+    <channel type="exporter" name="chanLightIsOn">FrontLightIsOn</channel>
+    <limits>[0, 100]</limits>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/kappa.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/kappa.xml
@@ -1,1 +1,15 @@
-exporter/kappa.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>Kappa</motor_name>
+    <username>Kappa</username>
+    <direction>1</direction>
+    <GUIstep>10</GUIstep>
+    <channel type="exporter" name="KappaPosition">KappaPosition</channel>
+    <channel type="exporter" name="KappaState">KappaState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getKappaDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/omega.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/omega.xml
@@ -1,1 +1,15 @@
-exporter/omega.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>Omega</motor_name>
+    <username>Omega</username>
+    <direction>-1</direction>
+    <GUIstep>45</GUIstep>
+    <channel type="exporter" name="OmegaPosition">OmegaPosition</channel>
+    <channel type="exporter" name="OmegaState">OmegaState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getOmegaDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/phase.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/phase.xml
@@ -1,1 +1,22 @@
-exporter/phase.xml
+<device class="NamedState">
+    <username>Phase</username>
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <channel type="exporter" name="state">CurrentPhase</channel>
+    <channel type="exporter" name="hardware_state">State</channel>
+    <command type="exporter" name="command">startsetphase</command>
+    <states>
+       <state>
+          <name>Centring</name>
+       </state>
+       <state>
+          <name>Transfer</name>
+       </state>
+       <state>
+          <name>BeamLocation</name>
+       </state>
+       <state>
+          <name>DataCollection</name>
+       </state>
+    </states>
+   <object href="/singleton_objects/guillotine" role="guillotine"/>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/phi.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/phi.xml
@@ -1,1 +1,15 @@
-exporter/phi.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>Phi</motor_name>
+    <username>Phi</username>
+    <direction>1</direction>
+    <GUIstep>10</GUIstep>
+    <channel type="exporter" name="PhiPosition">PhiPosition</channel>
+    <channel type="exporter" name="PhiState">PhiState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getPhiDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/predefined-zoom.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/predefined-zoom.xml
@@ -1,1 +1,13 @@
-exporter/predefined-zoom.xml
+<device class="MicrodiffZoom">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>Zoom</motor_name>
+    <channel type="exporter" name="predefined_position">CoaxialCameraZoomValue</channel>
+    <channel type="exporter" name="ZoomPosition">ZoomPosition</channel>
+    <channel type="exporter" name="ZoomState">ZoomState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getZoomDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillator.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillator.xml
@@ -1,1 +1,17 @@
-exporter/scintillator.xml
+<device class="NamedState">
+    <username>Scintillator</username>
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <channel type="exporter" name="state">ScintillatorPosition</channel>
+    <channel type="exporter" name="hardware_state">State</channel>
+    <states>
+       <state>
+          <name>PARK</name>
+       </state>
+       <state>
+          <name>SCINTILLATOR</name>
+       </state>
+       <state>
+          <name>PHOTODIODE</name>
+       </state>
+    </states>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillatorhorizontal.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillatorhorizontal.xml
@@ -1,1 +1,15 @@
-exporter/scintillatorhorizontal.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>ScintillatorHorizontal</motor_name>
+    <username>ScintillatorHorizontal</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="ScintillatorHorizontalPosition">ScintillatorHorizontalPosition</channel>
+    <channel type="exporter" name="ScintillatorHorizontalState">ScintillatorVerticalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getScintillatorHorizontalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillatorvertical.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/scintillatorvertical.xml
@@ -1,1 +1,15 @@
-exporter/scintillatorvertical.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>ScintillatorVertical</motor_name>
+    <username>ScintillatorVertical</username>
+    <direction>1</direction>
+    <GUIstep>0.1</GUIstep>
+    <channel type="exporter" name="ScintillatorVerticalPosition">ScintillatorVerticalPosition</channel>
+    <channel type="exporter" name="ScintillatorVerticalState">ScintillatorVerticalState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getScintillatorVerticalDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/tango_events/diffractometer.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/tango_events/diffractometer.xml
@@ -14,15 +14,15 @@
     <command type="tango" polling="events" name="saveCentringPositions">saveCentringPositions</command>
     <command type="tango" polling="events" name="getOmegaMotorDynamicScanLimits">getOmegaMotorDynamicScanLimits</command>
 
-    <object href="/goniometer/tango_events/omega" role="phi"/>
-    <object href="/goniometer/tango_events/alignmentz" role="phiz"/>
-    <object href="/goniometer/tango_events/alignmenty" role="phiy"/>
-    <object href="/goniometer/tango_events/predefined-zoom" role="zoom"/>
-    <object href="/goniometer/tango_events/centringtablefocus" role="focus"/>
-    <object href="/goniometer/tango_events/centringx" role="sampx"/>
-    <object href="/goniometer/tango_events/centringy" role="sampy"/>
-    <object href="/goniometer/tango_events/kappa" role="kappa"/>
-    <object href="/goniometer/tango_events/phi" role="kappa_phi"/>
+    <object href="/diffractometer/tango_events/omega" role="phi"/>
+    <object href="/diffractometer/tango_events/alignmentz" role="phiz"/>
+    <object href="/diffractometer/tango_events/alignmenty" role="phiy"/>
+    <object href="/diffractometer/tango_events/predefined-zoom" role="zoom"/>
+    <object href="/diffractometer/tango_events/centringtablefocus" role="focus"/>
+    <object href="/diffractometer/tango_events/centringx" role="sampx"/>
+    <object href="/diffractometer/tango_events/centringy" role="sampy"/>
+    <object href="/diffractometer/tango_events/kappa" role="kappa"/>
+    <object href="/diffractometer/tango_events/phi" role="kappa_phi"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/beaminfo" role="beam_info"/>
     <object href="/singleton_objects/centring-math" role="centring"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/tango_polling/diffractometer.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/tango_polling/diffractometer.xml
@@ -14,15 +14,15 @@
     <command type="tango" polling="1000" name="saveCentringPositions">saveCentringPositions</command>
     <command type="tango" polling="1000" name="getOmegaMotorDynamicScanLimits">getOmegaMotorDynamicScanLimits</command>
 
-    <object href="/goniometer/tango_polling/omega" role="phi"/>
-    <object href="/goniometer/tango_polling/alignmentz" role="phiz"/>
-    <object href="/goniometer/tango_polling/alignmenty" role="phiy"/>
-    <object href="/goniometer/tango_polling/predefined-zoom" role="zoom"/>
-    <object href="/goniometer/tango_polling/centringtablefocus" role="focus"/>
-    <object href="/goniometer/tango_polling/centringx" role="sampx"/>
-    <object href="/goniometer/tango_polling/centringy" role="sampy"/>
-    <object href="/goniometer/tango_polling/kappa" role="kappa"/>
-    <object href="/goniometer/tango_polling/phi" role="kappa_phi"/>
+    <object href="/diffractometer/tango_polling/omega" role="phi"/>
+    <object href="/diffractometer/tango_polling/alignmentz" role="phiz"/>
+    <object href="/diffractometer/tango_polling/alignmenty" role="phiy"/>
+    <object href="/diffractometer/tango_polling/predefined-zoom" role="zoom"/>
+    <object href="/diffractometer/tango_polling/centringtablefocus" role="focus"/>
+    <object href="/diffractometer/tango_polling/centringx" role="sampx"/>
+    <object href="/diffractometer/tango_polling/centringy" role="sampy"/>
+    <object href="/diffractometer/tango_polling/kappa" role="kappa"/>
+    <object href="/diffractometer/tango_polling/phi" role="kappa_phi"/>
     <object href="/singleton_objects/camera" role="camera"/>
     <object href="/singleton_objects/beaminfo" role="beam_info"/>
     <object href="/singleton_objects/centring-math" role="centring"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/zoom.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/diffractometer/zoom.xml
@@ -1,1 +1,15 @@
-exporter/zoom.xml
+<device class="MicrodiffMotor">
+    <exporter_address>172.19.10.119:9001</exporter_address>
+    <motor_name>Zoom</motor_name>
+    <username>Zoom</username>
+    <direction>1</direction>
+    <GUIstep>500</GUIstep>
+    <channel type="exporter" name="ZoomPosition">ZoomPosition</channel>
+    <channel type="exporter" name="ZoomState">ZoomState</channel>
+    <channel type="exporter" name="motor_states">MotorStates</channel>
+    <command type="exporter" name="abort">abort</command>
+    <command type="exporter" name="homing">startHomingMotor</command>
+    <command type="exporter" name="getZoomDynamicLimits">getMotorDynamicLimits</command>
+    <command type="exporter" name="get_limits">getMotorLimits</command>
+    <command type="exporter" name="get_max_speed">getMotorMaxSpeed</command>
+</device>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/experimental_methods/diffraction_methods.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/experimental_methods/diffraction_methods.xml
@@ -1,5 +1,5 @@
 <object class="PX2Collect">
-  <object href="/goniometer/diffractometer" role="diffractometer"/>
+  <object href="/diffractometer/diffractometer" role="diffractometer"/>
   <object href="/singleton_objects/Qt4_graphics-manager" role="graphics_manager"/>
   <object href="/singleton_objects/dbconnection" role="lims_client"/>
   <object href="/singleton_motors/photon_energy" role="energy"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_motors/resolution.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_motors/resolution.xml
@@ -1,9 +1,9 @@
 <equipment class="PX2Resolution">
     
-    <channel type="tango" tangoname="i11-ma-c03/op/mono1" polling="500" name="energy">energy</channel>
-    <channel type="tango" tangoname="i11-ma-c03/op/mono1" polling="500" name="energy_state">State</channel>
-    <channel type="tango" tangoname="i11-ma-cx1/dt/dtc_ccd.1-mt_ts" polling="500" name="detector_position">position</channel>
-    <channel type="tango" tangoname="i11-ma-cx1/dt/dtc_ccd.1-mt_ts" polling="500" name="detector_position_state">state</channel>
+    <channel type="tango" tangoname="i11-ma-c03/op/mono1" polling="2000" name="energy">energy</channel>
+    <channel type="tango" tangoname="i11-ma-c03/op/mono1" polling="2000" name="energy_state">State</channel>
+    <channel type="tango" tangoname="i11-ma-cx1/dt/dtc_ccd.1-mt_ts" polling="2000" name="detector_position">position</channel>
+    <channel type="tango" tangoname="i11-ma-cx1/dt/dtc_ccd.1-mt_ts" polling="2000" name="detector_position_state">state</channel>
 
     <object href="/tango_motors/detector_distance" role="detector_distance"/>
     <object href="/singleton_motors/photon_energy" role="energy"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/Qt4_graphics-manager.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/Qt4_graphics-manager.xml
@@ -1,5 +1,5 @@
 <object class="Qt4_GraphicsManager">
-    <object href="/goniometer/diffractometer" role="diffractometer"/>
+    <object href="/diffractometer/diffractometer" role="diffractometer"/>
     <object href="/singleton_objects/beaminfo_exporter" role="beam_info"/>
     <object href="/singleton_objects/camera" role="camera"/>
 

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beaminfo.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beaminfo.xml
@@ -5,7 +5,7 @@
     <channel type="exporter" name="beamsizey">BeamSizeVertical</channel>
     <channel type="exporter" name="positionx">BeamPositionHorizontal</channel>
     <channel type="exporter" name="positiony">BeamPositionVertical</channel>
-    <object  role="zoom"  hwrid="/goniometer/zoom"></object>
+    <object  role="zoom"  hwrid="/diffractometer/zoom"></object>
 
     <beam_divergence_hor>8</beam_divergence_hor>
     <beam_divergence_vert>3</beam_divergence_vert>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beaminfo_exporter.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beaminfo_exporter.xml
@@ -1,5 +1,5 @@
 <equipment class="EMBLBeamInfo">
-    <device hwrid="/goniometer/exporter/aperture" role="aperture"/>
+    <device hwrid="/diffractometer/aperture" role="aperture"/>
 
     <exporter_address>172.19.10.119:9001</exporter_address>
     <channel type="exporter" name="BeamPositionHorizontal">BeamPositionHorizontal</channel>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beamline-setup.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/beamline-setup.xml
@@ -1,9 +1,9 @@
 <object class="BeamlineSetup">
     <!-- Objects directly associatd with hardware -->
-    <object href="/goniometer/exporter/diffractometer" role="diffractometer"/>
-    <object href="/goniometer/exporter/omega" role="omega_axis"/>
-    <object href="/goniometer/exporter/kappa" role="kappa_axis"/>
-    <object href="/goniometer/exporter/phi" role="kappa_phi_axis"/>
+    <object href="/diffractometer/diffractometer" role="diffractometer"/>
+    <object href="/diffractometer/omega" role="omega_axis"/>
+    <object href="/diffractometer/kappa" role="kappa_axis"/>
+    <object href="/diffractometer/phi" role="kappa_phi_axis"/>
     <object href="/singleton_objects/cats" role="sample_changer"/>    
     <object href="/singleton_motors/resolution" role="resolution"/>
     <object href="/singleton_motors/photon_energy" role="energy"/>

--- a/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/centring-math.xml
+++ b/ExampleFiles/HardwareObjects.xml/soleil_px2/singleton_objects/centring-math.xml
@@ -5,37 +5,39 @@
   <gonioAxes>
      <axis>
         <motorname>phiy</motorname>
-        <direction>[0, 1, 0]</direction>
-	<type>translation</type>
-	<motorHO>/goniometer/alignmentz</motorHO> 
+        <direction>[1, 0, 0]</direction>
+        <type>translation</type>
+	<motorHO>/diffractometer/alignmenty</motorHO> 
      </axis>
      <!-- removing this axis (normal to Omega) will fix Omega position -->
      <axis>
         <motorname>phiz</motorname>
-        <direction>[1, 0, 0]</direction>
+        <direction>[0, -1, 0]</direction>
         <type>translation</type>
-        <motorHO>/goniometer/alignmenty</motorHO> 
+        <motorHO>/diffractometer/alignmentz</motorHO> 
      </axis>
      <axis>
         <motorname>phi</motorname>
         <!-- direction of omega at Chi==0 -->
-        <direction>[0, -1, 0]</direction>
+        <direction>[-1, 0, 0]</direction>
         <type>rotation</type>
-        <motorHO>/goniometer/omega</motorHO> 
+        <motorHO>/diffractometer/omega</motorHO> 
      </axis>
      <axis>
         <!-- direction of sampx at Chi==0 and Omega == 0 --> 
         <motorname>sampx</motorname>
-        <direction>[-0.281085,  0, 0.959683]</direction>
+        <!--direction>[-0.281085,  0, 0.959683]</direction-->
+        <direction>[0, 0, 1]</direction>
         <type>translation</type>
-        <motorHO>/goniometer/centringx</motorHO> 
+        <motorHO>/diffractometer/centringx</motorHO> 
      </axis>
 
      <axis>
         <motorname>sampy</motorname>
-        <direction>[0.959683,  0, 0.281085 ]</direction>
+        <!--direction>[0.959683,  0, 0.281085 ]</direction-->
+        <direction>[0, -1, 0]</direction>
         <type>translation</type>
-        <motorHO>/goniometer/centringy</motorHO> 
+        <motorHO>/diffractometer/centringy</motorHO> 
      </axis>
   </gonioAxes>
   <cameraAxes>


### PR DESCRIPTION
Add beamline-setup.xml to the toplevel configuration directory for PX2.
 -- After recent merge the Qt4_TaskToolBoxBrick started to complain about
    not being able to find /beamline-setup although there is no mention of it
    in the .yml file (only /singleton_objects/beamline-setup is).
    This is just workaround before I figure it out.
--replace symbolic links in /diffractometer subdirectory by physical files.
   git does not seem to handle links.
--complete renaming /goniometer - /diffractometer
-- change polling of resolution (500->2000)
-- Update centring-math.xml with correct axes directions for MD2 of PX2. 

