### PR TITLE
HR Issue #274: Removed '_v1' from queue_model_objects_v1 and ...enumerables_v1

### DIFF
--- a/BlissFramework/Bricks/Qt4_HutchMenuBrick.py
+++ b/BlissFramework/Bricks/Qt4_HutchMenuBrick.py
@@ -17,14 +17,9 @@
 #   You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import logging
-import traceback
 
 from QtImport import *
-
-import queue_model_objects_v1 as queue_model_objects
-import Qt4_GraphicsManager as graphics_manager
 
 from BlissFramework import Qt4_Icons
 from BlissFramework.Utils import Qt4_widget_colors

--- a/BlissFramework/Bricks/Qt4_SampleDetailsBrick.py
+++ b/BlissFramework/Bricks/Qt4_SampleDetailsBrick.py
@@ -21,12 +21,10 @@ import os
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
-#from widgets.Qt4_ispyb_widget import ISPyBSampleInfoWidget
 from widgets.Qt4_widget_utils import DataModelInputBinder
 from BlissFramework.Qt4_BaseComponents import BlissWidget
-from BlissFramework.Utils import Qt4_widget_colors
 
 
 __credits__ = ["MXCuBE colaboration"]

--- a/BlissFramework/Bricks/Qt4_TaskToolBoxBrick.py
+++ b/BlissFramework/Bricks/Qt4_TaskToolBoxBrick.py
@@ -17,14 +17,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import logging
-import traceback
 
 from QtImport import *
-
-import Qt4_GraphicsManager as graphics_manager
-import queue_model_objects_v1 as queue_model_objects
 
 from widgets.Qt4_task_toolbox_widget import TaskToolBoxWidget
 from BlissFramework.Qt4_BaseComponents import BlissWidget
@@ -185,26 +180,27 @@ class Qt4_TaskToolBoxBrick(BlissWidget):
             self.task_tool_box_widget.enable_compression(new_value)
         elif property_name == 'showCollectNowButton':
             self.task_tool_box_widget.collect_now_button.setVisible(new_value)
-        elif property_name == 'showDiscreetTask':
-            if not new_value:
-                self.task_tool_box_widget.hide_task(\
-                     self.task_tool_box_widget.discrete_page) 
-        elif property_name == "showHelicalTask":
-            if not new_value:
-                self.task_tool_box_widget.hide_task(\
-                     self.task_tool_box_widget.helical_page)
-        elif property_name == "showCharTask":
-            if not new_value:
-                self.task_tool_box_widget.hide_task(\
-                     self.task_tool_box_widget.char_page)
-        elif property_name == "showAdvancedTask":
-            if not new_value:
-                self.task_tool_box_widget.hide_task(\
-                     self.task_tool_box_widget.advanced_page)
-        elif property_name == "showStillScanTask":
-            if not new_value:
-                self.task_tool_box_widget.hide_task(\
-                     self.task_tool_box_widget.still_scan_page)
+        # # NB new additino by IK, buthide_task is not defiend ANYWHERE
+        # elif property_name == 'showDiscreetTask':
+        #     if not new_value:
+        #         self.task_tool_box_widget.hide_task(\
+        #              self.task_tool_box_widget.discrete_page)
+        # elif property_name == "showHelicalTask":
+        #     if not new_value:
+        #         self.task_tool_box_widget.hide_task(\
+        #              self.task_tool_box_widget.helical_page)
+        # elif property_name == "showCharTask":
+        #     if not new_value:
+        #         self.task_tool_box_widget.hide_task(\
+        #              self.task_tool_box_widget.char_page)
+        # elif property_name == "showAdvancedTask":
+        #     if not new_value:
+        #         self.task_tool_box_widget.hide_task(\
+        #              self.task_tool_box_widget.advanced_page)
+        # elif property_name == "showStillScanTask":
+        #     if not new_value:
+        #         self.task_tool_box_widget.hide_task(\
+        #              self.task_tool_box_widget.still_scan_page)
 
     def selection_changed(self, items):
         """

--- a/BlissFramework/Bricks/Qt4_TreeBrick.py
+++ b/BlissFramework/Bricks/Qt4_TreeBrick.py
@@ -29,7 +29,7 @@ from BlissFramework.Utils import Qt4_widget_colors
 from BlissFramework.Qt4_BaseComponents import BlissWidget
 from Qt4_sample_changer_helper import SC_STATE_COLOR, SampleChanger
 from widgets.Qt4_dc_tree_widget import DataCollectTree
-from queue_model_enumerables_v1 import CENTRING_METHOD
+from queue_model_enumerables import CENTRING_METHOD
 
 
 __credits__ = ["MXCuBE colaboration"]

--- a/BlissFramework/Bricks/Qt4_queue_item.py
+++ b/BlissFramework/Bricks/Qt4_queue_item.py
@@ -23,7 +23,7 @@ from QtImport import *
 from BlissFramework import Qt4_Icons
 from BlissFramework.Utils import Qt4_widget_colors
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 
 PIN_ICON = Qt4_Icons.load_icon("sample_axis")

--- a/BlissFramework/Bricks/SOLEIL/TaskToolBoxBrickPX2.py
+++ b/BlissFramework/Bricks/SOLEIL/TaskToolBoxBrickPX2.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-import os
 import qt
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import logging
 import traceback
 import ShapeHistory as shape_history

--- a/BlissFramework/Bricks/SampleDetailsBrick.py
+++ b/BlissFramework/Bricks/SampleDetailsBrick.py
@@ -1,5 +1,5 @@
 import qt
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 
 from BlissFramework import BaseComponents

--- a/BlissFramework/Bricks/TaskToolBoxBrick.py
+++ b/BlissFramework/Bricks/TaskToolBoxBrick.py
@@ -1,6 +1,5 @@
-import os
 import qt
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import logging
 import traceback
 import ShapeHistory as shape_history

--- a/BlissFramework/Bricks/queue_item.py
+++ b/BlissFramework/Bricks/queue_item.py
@@ -1,4 +1,4 @@
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import qt
 
 from BlissFramework import Icons

--- a/BlissFramework/Bricks/widgets/Qt4_acquisition_still_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_acquisition_still_widget.py
@@ -21,10 +21,9 @@
 import os
 
 from QtImport import *
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.Qt4_widget_utils import DataModelInputBinder
-from BlissFramework.Utils import Qt4_widget_colors
 
 
 class AcquisitionStillWidget(QWidget):

--- a/BlissFramework/Bricks/widgets/Qt4_acquisition_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_acquisition_widget.py
@@ -23,10 +23,9 @@ import logging
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.Qt4_widget_utils import DataModelInputBinder
-from BlissFramework.Utils import Qt4_widget_colors
 
 
 MAD_ENERGY_COMBO_NAMES = {'ip': 0, 'pk': 1, 'rm1': 2, 'rm2': 3}

--- a/BlissFramework/Bricks/widgets/Qt4_acquisition_widget_simple.py
+++ b/BlissFramework/Bricks/widgets/Qt4_acquisition_widget_simple.py
@@ -21,7 +21,7 @@ import os
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 from widgets.Qt4_widget_utils import DataModelInputBinder
 
 

--- a/BlissFramework/Bricks/widgets/Qt4_advanced_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_advanced_parameters_widget.py
@@ -17,11 +17,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from QtImport import *
-
-import queue_model_objects_v1 as queue_model_objects
 
 import Qt4_queue_item
 from widgets.Qt4_widget_utils import DataModelInputBinder

--- a/BlissFramework/Bricks/widgets/Qt4_advanced_results_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_advanced_results_widget.py
@@ -17,13 +17,10 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from QtImport import *
 
 import Qt4_queue_item
 
-import queue_model_objects_v1 as queue_model_objects
 from widgets.Qt4_heat_map_widget import HeatMapWidget
 
 

--- a/BlissFramework/Bricks/widgets/Qt4_char_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_char_parameters_widget.py
@@ -20,19 +20,14 @@
 from QtImport import *
 
 import os
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
-from BlissFramework.Utils import Qt4_widget_colors
 from widgets.Qt4_widget_utils import DataModelInputBinder
 from widgets.Qt4_reference_image_widget import ReferenceImageWidget
 from widgets.Qt4_char_type_widget import CharTypeWidget
 from widgets.Qt4_optimisation_parameters_widget_layout\
     import OptimisationParametersWidgetLayout
-from widgets.Qt4_radiation_damage_model_widget_layout\
-    import RadiationDamageModelWidgetLayout
-from widgets.Qt4_vertical_crystal_dimension_widget_layout\
-    import VerticalCrystalDimensionWidgetLayout
 
 
 class CharParametersWidget(QWidget):

--- a/BlissFramework/Bricks/widgets/Qt4_confirm_dialog.py
+++ b/BlissFramework/Bricks/widgets/Qt4_confirm_dialog.py
@@ -22,7 +22,7 @@ import os
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 from BlissFramework.Utils import Qt4_widget_colors
 
 

--- a/BlissFramework/Bricks/widgets/Qt4_create_advanced_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_advanced_widget.py
@@ -24,12 +24,11 @@ import logging
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from Qt4_create_task_base import CreateTaskBase
 from widgets.Qt4_data_path_widget import DataPathWidget
 from widgets.Qt4_acquisition_widget import AcquisitionWidget
-from queue_model_enumerables_v1 import EXPERIMENT_TYPE
 
 
 class CreateAdvancedWidget(CreateTaskBase):

--- a/BlissFramework/Bricks/widgets/Qt4_create_char_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_char_widget.py
@@ -23,15 +23,14 @@ import copy
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 from Qt4_GraphicsLib import GraphicsItemPoint
 
 from widgets.Qt4_widget_utils import DataModelInputBinder
 from Qt4_create_task_base import CreateTaskBase
 from Qt4_data_path_widget import DataPathWidget
 from Qt4_acquisition_widget_simple import AcquisitionWidgetSimple
-from queue_model_enumerables_v1 import XTAL_SPACEGROUPS
 
 
 class CreateCharWidget(CreateTaskBase):
@@ -136,7 +135,9 @@ class CreateCharWidget(CreateTaskBase):
                               self._vertical_dimension_widget.max_vphi_ledit, float,
                               QDoubleValidator(0.0, 1000, 2, self))
         
-        self._vertical_dimension_widget.space_group_ledit.addItems(XTAL_SPACEGROUPS)
+        self._vertical_dimension_widget.space_group_ledit.addItems(
+            queue_model_enumerables.XTAL_SPACEGROUPS
+        )
 
         self._data_path_widget.data_path_layout.compression_cbox.setVisible(False)
 
@@ -153,8 +154,9 @@ class CreateCharWidget(CreateTaskBase):
         """
         Descript. :
         """
-        self._char_params.space_group = queue_model_enumerables.\
-                                        XTAL_SPACEGROUPS[index]
+        self._char_params.space_group = (
+            queue_model_enumerables.XTAL_SPACEGROUPS[index]
+        )
 
     def _set_space_group(self, space_group):
         """
@@ -163,8 +165,8 @@ class CreateCharWidget(CreateTaskBase):
         index  = 0
      
         if self._vertical_dimension_widget: 
-            if space_group in XTAL_SPACEGROUPS:
-                index = XTAL_SPACEGROUPS.index(space_group)
+            if space_group in queue_model_enumerables.XTAL_SPACEGROUPS:
+                index = queue_model_enumerables.XTAL_SPACEGROUPS.index(space_group)
 
             self._space_group_change(index)
             self._vertical_dimension_widget.space_group_ledit.\

--- a/BlissFramework/Bricks/widgets/Qt4_create_discrete_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_discrete_widget.py
@@ -22,11 +22,10 @@ import copy
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 from Qt4_GraphicsLib import GraphicsItemPoint
 
-from BlissFramework.Utils import Qt4_widget_colors
 from Qt4_data_path_widget import DataPathWidget
 from Qt4_processing_widget import ProcessingWidget
 from Qt4_acquisition_widget import AcquisitionWidget

--- a/BlissFramework/Bricks/widgets/Qt4_create_energy_scan_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_energy_scan_widget.py
@@ -24,10 +24,8 @@ from QtImport import *
 
 import Qt4_queue_item
 from Qt4_GraphicsLib import GraphicsItemPoint
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
-from queue_model_enumerables_v1 import EXPERIMENT_TYPE
-from queue_model_enumerables_v1 import COLLECTION_ORIGIN
 from Qt4_create_task_base import CreateTaskBase
 from Qt4_data_path_widget import DataPathWidget
 from Qt4_periodic_table_widget import PeriodicTableWidget

--- a/BlissFramework/Bricks/widgets/Qt4_create_gphl_workflow_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_gphl_workflow_widget.py
@@ -1,9 +1,9 @@
 from PyQt4 import QtGui
 from PyQt4 import QtCore
 import Qt4_queue_item as queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
-from queue_model_enumerables_v1 import States
+from queue_model_enumerables import States
 
 from Qt4_create_task_base import CreateTaskBase
 from widgets.Qt4_data_path_widget import DataPathWidget

--- a/BlissFramework/Bricks/widgets/Qt4_create_helical_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_helical_widget.py
@@ -24,10 +24,10 @@ import logging
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 from Qt4_GraphicsLib import GraphicsItemLine
 
-from queue_model_enumerables_v1 import EXPERIMENT_TYPE
+from queue_model_enumerables import EXPERIMENT_TYPE
 from Qt4_create_task_base import CreateTaskBase
 from Qt4_data_path_widget import DataPathWidget
 from Qt4_acquisition_widget import AcquisitionWidget

--- a/BlissFramework/Bricks/widgets/Qt4_create_still_scan_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_still_scan_widget.py
@@ -17,16 +17,14 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import copy
 
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
-from widgets.Qt4_widget_utils import DataModelInputBinder
 from Qt4_create_task_base import CreateTaskBase
 from Qt4_acquisition_still_widget import AcquisitionStillWidget
 from Qt4_data_path_widget import DataPathWidget

--- a/BlissFramework/Bricks/widgets/Qt4_create_task_base.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_task_base.py
@@ -26,9 +26,8 @@ from copy import deepcopy
 from QtImport import *
 
 import Qt4_queue_item
-import Qt4_GraphicsManager
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
 
 class CreateTaskBase(QWidget):

--- a/BlissFramework/Bricks/widgets/Qt4_create_xray_imaging_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_xray_imaging_widget.py
@@ -27,8 +27,8 @@ from widgets.Qt4_acquisition_widget import AcquisitionWidget
 from widgets.Qt4_xray_imaging_parameters_widget import XrayImagingParametersWidget
 
 from Qt4_GraphicsLib import GraphicsItemPoint
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
 
 class CreateXrayImagingWidget(CreateTaskBase):

--- a/BlissFramework/Bricks/widgets/Qt4_create_xrf_spectrum_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_create_xrf_spectrum_widget.py
@@ -9,7 +9,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with MXCuBE.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
 import copy
 import logging
 
@@ -17,7 +16,7 @@ from QtImport import *
 
 import Qt4_queue_item
 from Qt4_GraphicsLib import GraphicsItemPoint
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from Qt4_create_task_base import CreateTaskBase
 from widgets.Qt4_data_path_widget import DataPathWidget

--- a/BlissFramework/Bricks/widgets/Qt4_data_path_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_data_path_widget.py
@@ -23,7 +23,7 @@ import logging
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 from widgets.Qt4_widget_utils import DataModelInputBinder
 from BlissFramework.Utils import Qt4_widget_colors
 

--- a/BlissFramework/Bricks/widgets/Qt4_dc_tree_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_dc_tree_widget.py
@@ -34,13 +34,13 @@ from QtImport import *
 
 import Qt4_queue_item
 import queue_entry
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from BlissFramework import Qt4_Icons
 from BlissFramework.Utils import Qt4_widget_colors
 from widgets.Qt4_confirm_dialog import ConfirmDialog
 from widgets.Qt4_plate_navigator_widget import PlateNavigatorWidget
-from queue_model_enumerables_v1 import CENTRING_METHOD
+from queue_model_enumerables import CENTRING_METHOD
 
 
 __credits__ = ["MxCuBE colaboration"]

--- a/BlissFramework/Bricks/widgets/Qt4_energy_scan_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_energy_scan_parameters_widget.py
@@ -19,15 +19,12 @@
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.Qt4_data_path_widget import DataPathWidget
 from widgets.Qt4_periodic_table_widget import PeriodicTableWidget
-#from widgets.Qt4_matplot_widget import TwoAxisPlotWidget
 from widgets.Qt4_pymca_plot_widget import PymcaPlotWidget
 from widgets.Qt4_snapshot_widget import SnapshotWidget
-
-from BlissFramework.Utils import Qt4_widget_colors
 
 
 class EnergyScanParametersWidget(QWidget):

--- a/BlissFramework/Bricks/widgets/Qt4_gphl_acquisition_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_gphl_acquisition_widget.py
@@ -3,7 +3,7 @@
 import logging
 from collections import namedtuple
 
-import queue_model_enumerables_v1 as enumerables
+import queue_model_enumerables
 
 from PyQt4 import QtCore
 from PyQt4 import QtGui
@@ -403,10 +403,11 @@ class GphlAcquisitionWidget(GphlSetupWidget):
             ll = self._pulldowns['space_group'] = []
             if data.crystal_system:
                 ll.append('')
-                ll.extend([x.name for x in enumerables.SPACEGROUP_DATA
+                ll.extend([x.name
+                           for x in queue_model_enumerables.SPACEGROUP_DATA
                            if x.point_group in data.point_groups])
             else:
-                ll.extend(enumerables.XTAL_SPACEGROUPS)
+                ll.extend(queue_model_enumerables.XTAL_SPACEGROUPS)
 
             widget = self._widget_data['space_group'][0]
             widget.clear()

--- a/BlissFramework/Bricks/widgets/Qt4_processing_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_processing_widget.py
@@ -21,8 +21,8 @@ import os
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 from widgets.Qt4_widget_utils import DataModelInputBinder
 
 

--- a/BlissFramework/Bricks/widgets/Qt4_task_toolbox_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_task_toolbox_widget.py
@@ -22,7 +22,7 @@ import logging
 from QtImport import *
 
 import Qt4_queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from BlissFramework import Qt4_Icons
 from widgets.Qt4_create_discrete_widget import CreateDiscreteWidget

--- a/BlissFramework/Bricks/widgets/Qt4_xray_imaging_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_xray_imaging_parameters_widget.py
@@ -22,10 +22,9 @@ import os
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.Qt4_widget_utils import DataModelInputBinder
-from BlissFramework.Utils import Qt4_widget_colors
 
 
 class XrayImagingParametersWidget(QWidget):

--- a/BlissFramework/Bricks/widgets/Qt4_xrf_spectrum_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/Qt4_xrf_spectrum_parameters_widget.py
@@ -19,9 +19,8 @@
 
 from QtImport import *
 
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
-from BlissFramework.Utils import Qt4_widget_colors
 from widgets.Qt4_data_path_widget import DataPathWidget
 from widgets.Qt4_mca_spectrum_widget import McaSpectrumWidget
 from widgets.Qt4_snapshot_widget import SnapshotWidget

--- a/BlissFramework/Bricks/widgets/acquisition_widget.py
+++ b/BlissFramework/Bricks/widgets/acquisition_widget.py
@@ -1,7 +1,7 @@
 import os
 import qt
 import qtui
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.widget_utils import DataModelInputBinder
 from BlissFramework.Utils import widget_colors

--- a/BlissFramework/Bricks/widgets/acquisition_widget_simple.py
+++ b/BlissFramework/Bricks/widgets/acquisition_widget_simple.py
@@ -1,7 +1,7 @@
 import os
 import qt
 import qtui
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.widget_utils import DataModelInputBinder
 

--- a/BlissFramework/Bricks/widgets/char_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/char_parameters_widget.py
@@ -1,8 +1,8 @@
 import os
 import qt
 import qtui
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
 from widgets.reference_image_widget import ReferenceImageWidget
 from widgets.char_type_widget import CharTypeWidget

--- a/BlissFramework/Bricks/widgets/confirm_dialog.py
+++ b/BlissFramework/Bricks/widgets/confirm_dialog.py
@@ -1,7 +1,7 @@
 import os
 import qt
 import queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.confirm_dialog_widget_vertical_layout \
      import ConfirmDialogWidgetVerticalLayout

--- a/BlissFramework/Bricks/widgets/create_char_widget.py
+++ b/BlissFramework/Bricks/widgets/create_char_widget.py
@@ -2,8 +2,8 @@ import os
 import qtui
 import qt
 import copy
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 import queue_item
 import ShapeHistory as shape_history
 
@@ -11,8 +11,6 @@ from widgets.widget_utils import DataModelInputBinder
 from create_task_base import CreateTaskBase
 from widgets.data_path_widget import DataPathWidget
 from acquisition_widget_simple import AcquisitionWidgetSimple
-
-from queue_model_enumerables_v1 import XTAL_SPACEGROUPS
 
 
 class CreateCharWidget(CreateTaskBase):
@@ -126,7 +124,9 @@ class CreateCharWidget(CreateTaskBase):
                               max_vphi_ledit, float,
                               qt.QDoubleValidator(0.0, 1000, 2, self))
         
-        space_group_ledit.insertStrList(XTAL_SPACEGROUPS)
+        space_group_ledit.insertStrList(
+            queue_model_enumerables.XTAL_SPACEGROUPS
+        )
 
         prefix_ledit = self._data_path_widget.\
                        data_path_widget_layout.child('prefix_ledit')
@@ -157,13 +157,14 @@ class CreateCharWidget(CreateTaskBase):
         self._acquisition_parameters.induce_burn = state
 
     def _space_group_change(self, index):
-       self._char_params.space_group = queue_model_enumerables.\
-                                       XTAL_SPACEGROUPS[index]
+       self._char_params.space_group = (
+           queue_model_enumerables.XTAL_SPACEGROUPS[index]
+       )
     def _set_space_group(self, space_group):
         index  = 0
         
-        if space_group in XTAL_SPACEGROUPS:
-            index = XTAL_SPACEGROUPS.index(space_group)
+        if space_group in queue_model_enumerables.XTAL_SPACEGROUPS:
+            index = queue_model_enumerables.XTAL_SPACEGROUPS.index(space_group)
 
         self._space_group_change(index)
         self._vertical_dimension_widget.\

--- a/BlissFramework/Bricks/widgets/create_discrete_widget.py
+++ b/BlissFramework/Bricks/widgets/create_discrete_widget.py
@@ -3,8 +3,8 @@ import qt
 import ShapeHistory as shape_history
 import queue_item
 
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
 from widgets.data_path_widget import DataPathWidget
 from widgets.processing_widget import ProcessingWidget

--- a/BlissFramework/Bricks/widgets/create_energy_scan_widget.py
+++ b/BlissFramework/Bricks/widgets/create_energy_scan_widget.py
@@ -2,7 +2,7 @@ import qt
 import logging
 import copy
 import queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import sys
 import ShapeHistory as shape_history
 

--- a/BlissFramework/Bricks/widgets/create_helical_widget.py
+++ b/BlissFramework/Bricks/widgets/create_helical_widget.py
@@ -1,7 +1,7 @@
 import logging
 import qt
 import copy
-import queue_model_objects_v1 as qmo
+import queue_model_objects as qmo
 import queue_item
 
 import ShapeHistory as shape_history
@@ -11,8 +11,7 @@ from widgets.data_path_widget import DataPathWidget
 from widgets.acquisition_widget import AcquisitionWidget
 from widgets.processing_widget import ProcessingWidget
 
-from queue_model_enumerables_v1 import EXPERIMENT_TYPE
-from queue_model_enumerables_v1 import COLLECTION_ORIGIN
+from queue_model_enumerables import EXPERIMENT_TYPE
 
 class CreateHelicalWidget(CreateTaskBase):
     def __init__(self, parent = None,name = None, fl = 0):

--- a/BlissFramework/Bricks/widgets/create_task_base.py
+++ b/BlissFramework/Bricks/widgets/create_task_base.py
@@ -1,8 +1,8 @@
 import qt
 import logging
 import queue_item
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 import abc
 import copy
 import ShapeHistory as shape_history

--- a/BlissFramework/Bricks/widgets/create_workflow_widget.py
+++ b/BlissFramework/Bricks/widgets/create_workflow_widget.py
@@ -1,7 +1,6 @@
 import qt
-import copy
 import queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import MxLookupScanBrick
 import itertools
 

--- a/BlissFramework/Bricks/widgets/create_xrf_scan_widget.py
+++ b/BlissFramework/Bricks/widgets/create_xrf_scan_widget.py
@@ -4,7 +4,7 @@ import logging
 import copy
 import queue_item
 import ShapeHistory as shape_history
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from create_task_base import CreateTaskBase
 from widgets.widget_utils import DataModelInputBinder

--- a/BlissFramework/Bricks/widgets/create_xrf_spectrum_widget.py
+++ b/BlissFramework/Bricks/widgets/create_xrf_spectrum_widget.py
@@ -4,7 +4,7 @@ import logging
 import copy
 import queue_item
 import ShapeHistory as shape_history
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from create_task_base import CreateTaskBase
 from widgets.widget_utils import DataModelInputBinder

--- a/BlissFramework/Bricks/widgets/data_path_widget.py
+++ b/BlissFramework/Bricks/widgets/data_path_widget.py
@@ -2,7 +2,7 @@ import qtui
 import qt
 import os
 import logging
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.widget_utils import DataModelInputBinder
 from BlissFramework.Utils import widget_colors

--- a/BlissFramework/Bricks/widgets/dc_tree_widget.py
+++ b/BlissFramework/Bricks/widgets/dc_tree_widget.py
@@ -1,7 +1,7 @@
 import qt
 import logging
 import gevent
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 import queue_item
 import queue_entry
 
@@ -9,7 +9,7 @@ from collections import namedtuple
 from BlissFramework import Icons
 from BlissFramework.Utils import widget_colors
 from widgets.confirm_dialog import ConfirmDialog
-from queue_model_enumerables_v1 import CENTRING_METHOD
+from queue_model_enumerables import CENTRING_METHOD
 
 SCFilterOptions = namedtuple('SCFilterOptions', 
                              ['SAMPLE_CHANGER', 'MOUNTED_SAMPLE', 'FREE_PIN', 'PLATE'])

--- a/BlissFramework/Bricks/widgets/energy_scan_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/energy_scan_parameters_widget.py
@@ -1,5 +1,5 @@
 import qt
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 #from PyMca import QPeriodicTable
 from PeriodicTableBrick import PeriodicTableBrick

--- a/BlissFramework/Bricks/widgets/processing_widget.py
+++ b/BlissFramework/Bricks/widgets/processing_widget.py
@@ -1,8 +1,8 @@
 import os
 import qtui
 import qt
-import queue_model_objects_v1 as queue_model_objects
-import queue_model_enumerables_v1 as queue_model_enumerables
+import queue_model_objects
+import queue_model_enumerables
 
 from widgets.widget_utils import DataModelInputBinder
 

--- a/BlissFramework/Bricks/widgets/task_toolbox_widget.py
+++ b/BlissFramework/Bricks/widgets/task_toolbox_widget.py
@@ -1,7 +1,7 @@
 import logging
 import qt
 import queue_item
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from BlissFramework import Icons
 from widgets.create_helical_widget import CreateHelicalWidget
@@ -10,7 +10,7 @@ from widgets.create_char_widget import CreateCharWidget
 from widgets.create_energy_scan_widget import CreateEnergyScanWidget
 from widgets.create_xrf_spectrum_widget import CreateXRFSpectrumWidget
 from widgets.create_workflow_widget import CreateWorkflowWidget
-from queue_model_enumerables_v1 import EXPERIMENT_TYPE
+from queue_model_enumerables import EXPERIMENT_TYPE
 
 
 class TaskToolBoxWidget(qt.QWidget):

--- a/BlissFramework/Bricks/widgets/xrf_spectrum_parameters_widget.py
+++ b/BlissFramework/Bricks/widgets/xrf_spectrum_parameters_widget.py
@@ -1,7 +1,7 @@
 import os
 import qt
 import qtui
-import queue_model_objects_v1 as queue_model_objects
+import queue_model_objects
 
 from widgets.data_path_widget import DataPathWidget
 from McaSpectrumBrick import McaSpectrumBrick

--- a/BlissFramework/Qt4_startGUI.py
+++ b/BlissFramework/Qt4_startGUI.py
@@ -49,6 +49,7 @@ _logger.addHandler(_GUIhdlr)
 
 
 __credits__ = ["MXCuBE colaboration"]
+__version__ = 2.3
 
 
 def do_gevent():


### PR DESCRIPTION
Completing solution to HardwareRepository issue #274
A couple of bug fixes:
- Added missing __version__
- Commented out calls to undefined 'hide_task()'