### PR TITLE
Enbled pylint warnings, and disabled bad-continuation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -60,7 +60,8 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,protected-access
+# disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating,protected-access
+disable=bad-continuation
 
 
 [REPORTS]

--- a/gui/qt3/Bricks/ResolutionBrick.py
+++ b/gui/qt3/Bricks/ResolutionBrick.py
@@ -337,9 +337,9 @@ class ResolutionBrick(BlissWidget):
             elif unit == "mm":
                 if self.detectorLimits is not None:
                     if val >= self.detectorLimits[0] and val <= self.detectorLimits[1]:
-                        param_dict["detdistance"] = val
+                        param_dict["detector_distance"] = val
                 else:
-                    param_dict["detdistance"] = val
+                    param_dict["detector_distance"] = val
 
         try:
             curr_resolution = float(self.currentResolutionValue)


### PR DESCRIPTION
This proposal is the same idea as mxcube/HardwareRepository #367
It enables all checks, and disables the bad-continuation check that (because of a bug in pylint) gives errors for the formatting proposed by black.