### PR TITLE
Bug fix: calls to BaseWidget in GUIBuilder

### DIFF
--- a/gui/GUIBuilder.py
+++ b/gui/GUIBuilder.py
@@ -849,10 +849,10 @@ class GUIEditorWindow(QtImport.QWidget):
                         self, "Cannot add item", new_item, QtImport.QMessageBox.Ok
                     )
                 else:
-                    new_item["properties"].getProperty("w").setValue(
+                    new_item["properties"].get_property("w").set_value(
                         QtImport.QApplication.desktop().width()
                     )
-                    new_item["properties"].getProperty("h").setValue(
+                    new_item["properties"].get_property("h").set_value(
                         QtImport.QApplication.desktop().height()
                     )
                     new_list_item = self.append_item(


### PR DESCRIPTION
Bug on calls to "get property" and "set value" functions : I guess that code was not updated after BaseWidget and PropertyBag refactoring