### PR TITLE
Add brick subfolders

### DIFF
--- a/docs/source/installation_instructions_qt4.rst
+++ b/docs/source/installation_instructions_qt4.rst
@@ -6,7 +6,7 @@ In this page a sequence how to get software code, install dependencies and execu
 Tested with:
 
 * Linux: Ubuntu 10, 12, 14, 16 (with gnome and kde) and Centos 7 (with gnome)
-* Macos.
+* MacOs.
 
 *****************
 1. Git repository
@@ -44,6 +44,7 @@ Other dependencies:
 * `enum34 <https://pypi.org/project/enum34/>`_
 * `PyChooch <http://github.com/mxcube/pychooch>`_
 * `PyMca <http://sourceforge.net/projects/pymca/>`_
+* `OpenCV <https://pypi.org/project/opencv-python/>`_
 
 2.1. Debian/Ubuntu
 ==================
@@ -65,7 +66,7 @@ Python 3x
 
 .. code-block:: bash
 
-   sudo pip3 install PyQt5 gevent numpy scipy matplotlib jsonpickle
+   sudo pip3 install PyQt5 gevent numpy scipy matplotlib jsonpickle PyMca5 opencv-python enum34 Louie suds3 PyYAML PyMca5
 
 2.2. Fedora/Centos
 ==================

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -70,7 +70,6 @@ logging.getLogger().addHandler(_hdlr)
 gui_path = os.path.dirname(__file__)
 sys.path.insert(0, gui_path)
 
-
 def get_base_bricks_path():
     std_bricks_pkg = __import__(STD_BRICKS_LOCATION, globals(), locals(), [""])
     return os.path.dirname(std_bricks_pkg.__file__)
@@ -96,7 +95,10 @@ def add_custom_bricks_dirs(bricks_dirs):
         _bricks_dirs += new_bricks_dirs
 
 
+base_bricks_path = get_base_bricks_path()
 sys.path.insert(0, get_base_bricks_path())
+# add 'EMBL' 'ESRF' 'ALBA' ... subfolders to path
+[sys.path.insert(0, f.path) for f in os.scandir(base_bricks_path) if f.is_dir() and f.name != "__pycache__"]
 
 
 def get_custom_bricks_dirs():


### PR DESCRIPTION
Right now, when adding bricks from brick subfolders ( EMBL, ALBA... ) an error message is displayed by the designer: 'module not found' ( or kind of )
On bricks/__init__.py file I've added 'brick' subfolders to the path ( __pycache__ excepted ) so those bricks can be found