### PR TITLE
CameraBrick: QActionGroup for an exclusive selection on image scale menu

### DIFF
--- a/gui/bricks/CameraBrick.py
+++ b/gui/bricks/CameraBrick.py
@@ -236,7 +236,6 @@ class CameraBrick(BaseWidget):
                 self.connect(HWR.beamline.microscope, "infoMsg", self.set_info_msg)
                 self.graphics_view = HWR.beamline.microscope.get_graphics_view()
                 # self.graphics_camera_frame = HWR.beamline.microscope.get_camera_frame()
-                self.graphics_view.resize(700,700)
                 self.main_layout.addWidget(self.graphics_view)
                 self.main_layout.addWidget(self.info_widget)
                 self.set_fixed_size()

--- a/gui/bricks/CameraBrick.py
+++ b/gui/bricks/CameraBrick.py
@@ -57,7 +57,7 @@ class CameraBrick(BaseWidget):
         # Graphic elements-----------------------------------------------------
         self.info_widget = QtImport.QWidget(self)
         self.display_beam_size_cbox = QtImport.QCheckBox("Display beam size", self)
-        self.display_beam_size_cbox.setHidden(True)
+        self.display_beam_size_cbox.setHidden(False)
         self.coord_label = QtImport.QLabel(":", self)
         self.info_label = QtImport.QLabel(self)
         self.camera_control_dialog = CameraControlDialog(self)
@@ -236,6 +236,7 @@ class CameraBrick(BaseWidget):
                 self.connect(HWR.beamline.microscope, "infoMsg", self.set_info_msg)
                 self.graphics_view = HWR.beamline.microscope.get_graphics_view()
                 # self.graphics_camera_frame = HWR.beamline.microscope.get_camera_frame()
+                self.graphics_view.resize(700,700)
                 self.main_layout.addWidget(self.graphics_view)
                 self.main_layout.addWidget(self.info_widget)
                 self.set_fixed_size()
@@ -312,12 +313,14 @@ class CameraBrick(BaseWidget):
         self.image_scale_list = HWR.beamline.microscope.get_image_scale_list()
         if len(self.image_scale_list) > 0:
             self.image_scale_menu.setEnabled(True)
+            self.image_scale_action_group = QtImport.QActionGroup(self.image_scale_menu)
             for scale in self.image_scale_list:
                 # probably there is a way to use a single method for all actions
                 # by passing index. lambda function at first try did not work
-                self.image_scale_menu.addAction(
+                action_temp = self.image_scale_menu.addAction(
                     "%d %%" % (scale * 100), self.not_used_function
                 )
+                self.image_scale_action_group.addAction(action_temp)
             for action in self.image_scale_menu.actions():
                 action.setCheckable(True)
             self.image_scaled(HWR.beamline.microscope.get_image_scale())

--- a/gui/utils/QtImport.py
+++ b/gui/utils/QtImport.py
@@ -136,6 +136,7 @@ if (qt_variant == "PyQt5") or (qt_variant is None and not qt_imported):
         from PyQt5.QtWidgets import (
             QAbstractItemView,
             QAction,
+            QActionGroup,
             QApplication,
             QButtonGroup,
             QCheckBox,


### PR DESCRIPTION
Add QActionGroup to QtImport
Use it for a mutual exclusive menu when selecting scale on the right-click menu ( now, user can select several checkboxes at the same time )