### PR TITLE
Bug fix on GUI Editor: "hide" property not showing brick when unchecked

### DIFF
--- a/gui/BaseComponents.py
+++ b/gui/BaseComponents.py
@@ -1023,6 +1023,8 @@ class BaseWidget(Connectable.Connectable, QtImport.QFrame):
         elif property_name == "hide":
             if new_value:
                 self.setHidden(True)
+            else:
+                self.setVisible(True)
         else:
             try:
                 self.property_changed(property_name, old_value, new_value)


### PR DESCRIPTION
when unchecking hide property's checkbox, the brick does not show on editor. Now it does

