### PR TITLE
Fixing bugs in Motor Bricks

### DIFF
--- a/gui/bricks/ESRF/MotorBrick.py
+++ b/gui/bricks/ESRF/MotorBrick.py
@@ -23,6 +23,7 @@ The standard Motor brick.
 """
 
 import logging
+import numpy
 
 from gui.utils import Icons, Colors, QtImport
 from gui.BaseComponents import BaseWidget
@@ -348,12 +349,10 @@ class MotorSlider(QtImport.QWidget):
 
     def set_range(self, min, max):
         """Set slider's min and max values."""
-        logging.getLogger().error(f"def set_range : min {min} -max {max} " )
-        if min == float("-inf") or min is None:
-            min = -100#-2147483648
-        if max == float("inf") or max is None:
-            max = 100#2147483647
-        logging.getLogger().error(f"def set_range after if : min {min} -max {max} ")
+        if not numpy.isfinite(min) or min is None:
+            min = -1000#-2147483648
+        if not numpy.isfinite(max) or max is None:
+            max = 1000#2147483647
         self.slider.setRange(min, max)
         self.slider.setValue((max + min)/2)
         self.set_min(min)

--- a/gui/bricks/ESRF/MotorBrick.py
+++ b/gui/bricks/ESRF/MotorBrick.py
@@ -23,7 +23,6 @@ The standard Motor brick.
 """
 
 import logging
-import numpy
 
 from gui.utils import Icons, Colors, QtImport
 from gui.BaseComponents import BaseWidget
@@ -349,10 +348,6 @@ class MotorSlider(QtImport.QWidget):
 
     def set_range(self, min, max):
         """Set slider's min and max values."""
-        if not numpy.isfinite(min) or min is None:
-            min = -1000#-2147483648
-        if not numpy.isfinite(max) or max is None:
-            max = 1000#2147483647
         self.slider.setRange(min, max)
         self.slider.setValue((max + min)/2)
         self.set_min(min)
@@ -748,9 +743,9 @@ class MotorBrick(BaseWidget):
             )
 
             step = 1.0
-            if hasattr(self.motor_hwobj, "GUIStep"):
-                if self.motor_hwobj.GUIStep is not None:
-                    step = self.motor_hwobj.GUIStep
+            if hasattr(self.motor_hwobj, "GUIstep"):
+                if self.motor_hwobj.GUIstep is not None:
+                    step = self.motor_hwobj.GUIstep
 
             self.step_backward.set_value(step)
             self.step_forward.set_value(step)
@@ -844,11 +839,11 @@ class MotorBrick(BaseWidget):
                 )
 
                 step = 1.0
-                if hasattr(self.motor_hwobj, "GUIStep"):
-                    if self.motor_hwobj.GUIStep is not None:
-                        step = self.motor_hwobj.GUIStep
+                if hasattr(self.motor_hwobj, "GUIstep"):
+                    if self.motor_hwobj.GUIstep is not None:
+                        step = self.motor_hwobj.GUIstep
                 else:
-                    logging.getLogger().error(f"self.motor_hwobj has no GUIStep attribute")
+                    logging.getLogger().error(f"self.motor_hwobj has no GUIstep attribute")
                 
                 self.step_backward.set_value(step)
                 self.step_forward.set_value(step)

--- a/gui/bricks/MotorSpinBoxBrick.py
+++ b/gui/bricks/MotorSpinBoxBrick.py
@@ -20,6 +20,7 @@
 import sys
 import math
 import logging
+import numpy
 
 from gui.utils import Icons, Colors, QtImport
 from gui.BaseComponents import BaseWidget
@@ -121,6 +122,7 @@ class MotorSpinBoxBrick(BaseWidget):
             "Moves the motor to a specific "
             + "position or step by step; right-click for motor history"
         )
+        self.position_spinbox.setContextMenuPolicy(QtImport.Qt.CustomContextMenu)
 
         # Extra controls
         self.stop_button = QtImport.QPushButton(self.main_gbox)
@@ -175,7 +177,7 @@ class MotorSpinBoxBrick(BaseWidget):
         spinbox_event.returnPressedSignal.connect(self.change_position)
         spinbox_event.contextMenuSignal.connect(self.open_history_menu)
         self.position_spinbox.lineEdit().textEdited.connect(self.position_value_edited)
-
+        
         self.step_combo.activated.connect(self.go_to_step)
         self.step_combo.activated.connect(self.step_changed)
         self.step_combo.editTextChanged.connect(self.step_edited)
@@ -322,8 +324,8 @@ class MotorSpinBoxBrick(BaseWidget):
 
     def limits_changed(self, limits):
         # limits = self.make_limits_bounded(limits)
-
         if limits and not None in limits:
+            
             self.position_spinbox.blockSignals(True)
             self.position_spinbox.setMinimum(limits[0])
             self.position_spinbox.setMaximum(limits[1])
@@ -363,7 +365,7 @@ class MotorSpinBoxBrick(BaseWidget):
             self.position_history.insert(0, pos)
 
     def open_step_editor(self):
-        if self.isRunning():
+        if self.is_running():
             if self.step_editor is None:
                 self.step_editor = StepEditorDialog(self)
             self.step_editor.set_motor(
@@ -537,7 +539,7 @@ class MotorSpinBoxBrick(BaseWidget):
 
         if motor_ho_name is not None:
             self.motor_hwobj = self.get_hardware_object(motor_ho_name)
-
+            
         if self.motor_hwobj is None:
             # first time motor is set
             try:

--- a/gui/bricks/MotorSpinBoxBrick.py
+++ b/gui/bricks/MotorSpinBoxBrick.py
@@ -20,7 +20,6 @@
 import sys
 import math
 import logging
-import numpy
 
 from gui.utils import Icons, Colors, QtImport
 from gui.BaseComponents import BaseWidget


### PR DESCRIPTION
MotorSpinBox, set context menu policy so it does not show default context menu when right click.
Call to is running function refactored
MotorBrick, setting slider's limits