### PR TITLE
Utils import fix

### DIFF
--- a/mxcubeqt/gui_builder.py
+++ b/mxcubeqt/gui_builder.py
@@ -36,7 +36,7 @@ from mxcubeqt.bricks import log_view_brick
 from mxcubeqt.base_layout_items import ContainerCfg
 
 from mxcubecore import HardwareRepository as HWR
-from mxcubecore.ConvertUtils import string_types
+from mxcubecore.utils.conversion import string_types
 
 
 __credits__ = ["MXCuBE collaboration"]

--- a/mxcubeqt/utils/widget_utils.py
+++ b/mxcubeqt/utils/widget_utils.py
@@ -20,7 +20,7 @@
 
 from mxcubeqt.utils import colors, qt_import
 from mxcubecore.dispatcher import dispatcher
-from mxcubecore.ConvertUtils import string_types
+from mxcubecore.utils.conversion import string_types
 
 
 __credits__ = ["MXCuBE collaboration"]


### PR DESCRIPTION
During initial testing mockup startup of mxcubeqt GUI was not possible due to the import errors. This fix should help.  