### PR TITLE
Some bricks improvements

### DIFF
--- a/mxcubeqt/bricks/energy_brick.py
+++ b/mxcubeqt/bricks/energy_brick.py
@@ -50,9 +50,9 @@ class EnergyBrick(BaseWidget):
 
         # Graphic elements ----------------------------------------------------
         self.group_box = qt_import.QGroupBox("Energy", self)
-        energy_label = qt_import.QLabel("Current:", self.group_box)
-        energy_label.setFixedWidth(75)
-        wavelength_label = qt_import.QLabel("Wavelength: ", self.group_box)
+        current_label = qt_import.QLabel("Current:", self.group_box)
+        current_label.setFixedWidth(75)
+        
         self.energy_ledit = qt_import.QLineEdit(self.group_box)
         self.energy_ledit.setReadOnly(True)
         self.wavelength_ledit = qt_import.QLineEdit(self.group_box)
@@ -87,9 +87,8 @@ class EnergyBrick(BaseWidget):
         _new_value_widget_hlayout.setContentsMargins(0, 0, 0, 0)
 
         _group_box_gridlayout = qt_import.QGridLayout(self.group_box)
-        _group_box_gridlayout.addWidget(energy_label, 0, 0)
+        _group_box_gridlayout.addWidget(current_label, 0, 0, 2, 1)
         _group_box_gridlayout.addWidget(self.energy_ledit, 0, 1)
-        _group_box_gridlayout.addWidget(wavelength_label, 1, 0)
         _group_box_gridlayout.addWidget(self.wavelength_ledit, 1, 1)
         _group_box_gridlayout.addWidget(self.status_label, 2, 0)
         _group_box_gridlayout.addWidget(self.status_ledit, 2, 1)

--- a/mxcubeqt/bricks/motor_spinbox_brick.py
+++ b/mxcubeqt/bricks/motor_spinbox_brick.py
@@ -263,7 +263,7 @@ class MotorSpinboxBrick(BaseWidget):
 
     def move_down(self):
         # self.demand_move = -1
-        self.set_editing(False)   
+        self.set_editing(False)
         self.update_gui()
         state = self.motor_hwobj.get_state()
         if state == self.motor_hwobj.STATES.READY:
@@ -312,7 +312,7 @@ class MotorSpinboxBrick(BaseWidget):
 
     def limits_changed(self, limits):
         if limits and not(None in limits or any(math.isnan(x) for x in limits)):
-            #limits = self.make_limits_bounded(limits) 
+            #limits = self.make_limits_bounded(limits)
             self.position_spinbox.blockSignals(True)
             self.position_spinbox.setMinimum(limits[0])
             self.position_spinbox.setMaximum(limits[1])
@@ -451,7 +451,7 @@ class MotorSpinboxBrick(BaseWidget):
         if self.editing:
             colors.set_widget_color(
                 self.position_spinbox.lineEdit(),
-                qt_import.QColor(255, 165, 0),
+                colors.LINE_EDIT_CHANGED,
                 qt_import.QPalette.Base,
             )
         else:

--- a/mxcubeqt/bricks/phase_brick.py
+++ b/mxcubeqt/bricks/phase_brick.py
@@ -83,6 +83,7 @@ class PhaseBrick(BaseWidget):
             for phase in phase_list:
                 self.phase_combobox.addItem(phase)
             self.setEnabled(True)
+            self.phase_combobox.setCurrentIndex(self.phase_combobox.findText(HWR.beamline.diffractometer.current_phase))
         else:
             self.setEnabled(False)
 

--- a/mxcubeqt/bricks/resolution_brick.py
+++ b/mxcubeqt/bricks/resolution_brick.py
@@ -37,7 +37,7 @@ class ResolutionBrick(BaseWidget):
         colors.LIGHT_YELLOW,
         colors.LIGHT_YELLOW,
         colors.LIGHT_YELLOW,
-        qt_import.QColor(255, 165, 0),
+        colors.LIGHT_ORANGE,
         colors.LIGHT_RED,
     )
 
@@ -52,8 +52,8 @@ class ResolutionBrick(BaseWidget):
 
         # Properties ----------------------------------------------------------
         self.add_property("defaultMode", "combo", ("Ang", "mm"), "Ang")
-        self.add_property("mmFormatString", "formatString", "###.##")
-        self.add_property("angFormatString", "formatString", "##.###")
+        self.add_property("mmFormatString", "formatString", "###.###")
+        self.add_property("angFormatString", "formatString", "##.####")
 
         self.group_box = qt_import.QGroupBox("Resolution", self)
         current_label = qt_import.QLabel("Current:", self.group_box)


### PR DESCRIPTION
resolution_brick.py:
       use named color for alarm instead of rgb triplet
       icrease format string resolution to number of digits realistically available on moder equipment
energy_brick.py
       make label more coherent: both energy and wavelength are current
       display is now more akin to resolution_brick.py
motor_spinbox_brick.py
      - use named colour instead of rgb triplet when line edit changes
phase_brick.py
      - handle the case when the phase upon restart is not the first one

