### PR TITLE
Temp bug fix, and mock setup update

### DIFF
--- a/mxcubeqt/bricks/phase_brick.py
+++ b/mxcubeqt/bricks/phase_brick.py
@@ -115,7 +115,12 @@ class PhaseBrick(BaseWidget):
 
     def phase_changed(self, phase=None):
         if phase is None:
-            phase = HWR.beamline.diffractometer.get_phase()
+            try:
+                # NB get_phase is only defined in P11-specific code, so this is no good.
+                # What should be here??
+                phase = HWR.beamline.diffractometer.get_phase()
+            except AttributeError:
+                return
 
         if phase.lower() != "unknown" and self.phase_combobox.count() > 0:
             # index = self.phase_combobox.findText(phase)

--- a/start_mxcube
+++ b/start_mxcube
@@ -35,7 +35,8 @@ MOCKUP_XML_PATH="${MXCUBE_CORE}/configuration/mockup"
 MXCUBE_CORE_CONFIG_PATH="${MOCKUP_XML_PATH}/gphl:${MOCKUP_XML_PATH}/qt:${MOCKUP_XML_PATH}"
 
 # Specific for SOLEIL:
-MXCUBE_CORE_CONFIG_PATH="${MXCUBE_CORE_CONFIG_PATH}:${MXCUBE_CORE}/configuration/soleil/px2/mockups"
+# MXCUBE_CORE_CONFIG_PATH="${MXCUBE_CORE_CONFIG_PATH}:${MXCUBE_CORE}/configuration/soleil/px2/mockups"
+MXCUBE_CORE_CONFIG_PATH="${MXCUBE_CORE_CONFIG_PATH}:${MXCUBE_CORE}/configuration/embl_hh_p14/"
 
 # User name - used only for file names etc.
 USER_NAME="test_user"


### PR DESCRIPTION
There was a recent change that called a P11-specific function from site-independent code, and so broke the mock implementation (and likely others). I put it under try:   except:   temporarliy, but could someone who knows how it is supposed to work please take a loo at a proper fixk?

The rest is a GPhL-only bug fix.