### PR TITLE
Fixed machine_info_brick bug in Andrey Gruzinov 2024097 commit

### DIFF
--- a/mxcubeqt/bricks/machine_info_brick.py
+++ b/mxcubeqt/bricks/machine_info_brick.py
@@ -169,3 +169,4 @@ class CustomInfoWidget(qt_import.QWidget):
             self.value_plot.add_new_plot_value(value)
 
     def open_history_view(self):
+        self.value_plot.setVisible(not self.value_plot.isVisible())


### PR DESCRIPTION
If looks like one line too much was removed in a previous commit (making the code broken). This restores that line.